### PR TITLE
Emulate a FHS environment for building Gecko.

### DIFF
--- a/pkgs/nixpkgs.json
+++ b/pkgs/nixpkgs.json
@@ -1,6 +1,6 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs-channels",
-  "rev": "1c50bdd928cec055d2ca842e2cf567aba2584efc",
-  "sha256": "1g1504x8wbrvjzhjqmpl2c05wxglljxncqmfh1q38hfvkmmfl17g"
+  "rev": "2839b101f927be5daab7948421de00a6f6c084ae",
+  "sha256": "0a863cc5462gn1vws87d4qn45zk22m64ri1ip67w0b1a9bmymqdh"
 }


### PR DESCRIPTION
Some commands such as `mach talos` expect to download pre-compiled binaries and to execute them.

This pull request adds a work-around which create a FHS environment within a nix-shell to make these commands work.

```
  $ nix-shell ./release.nix -A gecko.x86_64-linux.gcc.fhs.env
  >$ ls -la /
```

cc @garbas