### PR TITLE
rust-overlay: patch SHEBANGS in install.sh

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -101,6 +101,7 @@ let
               for i in * ; do
                 if [ -d "$i" ]; then
                   cd $i
+                  patchShebangs install.sh
                   CFG_DISABLE_LDCONFIG=1 ./install.sh --prefix=$out --verbose
                   cd ..
                 fi


### PR DESCRIPTION
This prevents the system-wide `/bin/sh` to be used, which causes trouble
on travis-ci and the installed dash.

Fixes #23 