### PR TITLE
rust-overlay.nix: use armv7 triple when on armv7

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -30,7 +30,7 @@ let
     "x86_64-linux"    = "x86_64-unknown-linux-gnu";
     "armv5tel-linux"  = "arm-unknown-linux-gnueabi";
     "armv6l-linux"    = "arm-unknown-linux-gnueabi";
-    "armv7l-linux"    = "arm-unknown-linux-gnueabi";
+    "armv7l-linux"    = "armv7-unknown-linux-gnueabihf";
     "aarch64-linux"   = "aarch64-unknown-linux-gnu";
     "mips64el-linux"  = "mips64el-unknown-linux-gnuabi64";
     "x86_64-darwin"   = "x86_64-apple-darwin";


### PR DESCRIPTION
Fixes #32.

I've also had to override `buildRustPackage` to pass the environment variable `CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER="gcc";`, because otherwise Cargo (?) passes `-C linker=arm-linux-gnueabihf-gcc` to rustc and building crates with native components fails. I've used another overlay to do this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/nixpkgs-mozilla/34)
<!-- Reviewable:end -->
