### PR TITLE
Use HTTPS to download nigthly

### DIFF
--- a/pkgs/firefox-nightly-bin/update.nix
+++ b/pkgs/firefox-nightly-bin/update.nix
@@ -17,9 +17,10 @@ in writeScript "update-firefox-nightly-bin" ''
   pushd pkgs/firefox-nightly-bin
 
   tmpfile=`mktemp`
-  url=http://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/
+  url=https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/
 
-  nightly_file=`xidel -q $url --extract //a | \
+  nightly_file=`curl $url | \
+                xidel - --extract //a | \
                 grep firefox | \
                 grep linux-x86_64.json | \
                 tail -1 | \


### PR DESCRIPTION
Use https, with `curl` piping to `xidel` (which doesn't support https).

Ran into a problem where the tar file had the wrong sha512 over http via. curl/wget (confirmed on two machines on different networks).