### PR TITLE
servo: remove nil reference

### DIFF
--- a/servo-overlay.nix
+++ b/servo-overlay.nix
@@ -1,6 +1,5 @@
 self: super:
 
 {
-  rustPlatform = self.rustUnstable;
   servo = super.callPackage ./pkgs/servo { };
 }


### PR DESCRIPTION
self.rustUnstable is undefined

Fixes #59