### PR TITLE
Use gpg and gpgv commands

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -61,8 +61,8 @@ let
     } ''
       HOME=`mktemp -d`
       set -eux
-      cat ${./firefox.key} | gpg2 --import
-      gpgv2 --keyring=$HOME/.gnupg/pubring.kbx $CHKSUM_ASC $CHKSUM_FILE
+      cat ${./firefox.key} | gpg --import
+      gpgv --keyring=$HOME/.gnupg/pubring.kbx $CHKSUM_ASC $CHKSUM_FILE
       mkdir $out
     '';
 


### PR DESCRIPTION
The `self.gnupg` derivation currently defaults to `gnupg-2.1` which does not have the `gpg2` and `gpgv2` commands. They are simply called `gpg` and `gpgv`.

This is just a fix to allow Firefox to be installed from this overlay.