### PR TITLE
Fixes error with wrong import path for firefox-bin

### DIFF
--- a/pkgs/firefox-nightly-bin/default.nix
+++ b/pkgs/firefox-nightly-bin/default.nix
@@ -3,7 +3,7 @@
 
 let
 
-  unwrapped = pkgs.callPackage "${pkgs.path}/pkgs/applications/networking/browsers/firefox-bin" {
+  unwrapped = pkgs.firefox-bin-unwrapped.override {
     inherit (pkgs) stdenv;
     channel = "nightly";
     generated = import (./. + "/sources.nix");


### PR DESCRIPTION
Fixes the error mentioned in(second comment): https://github.com/mozilla/nixpkgs-mozilla/pull/60