### PR TITLE
rust-src-overlay.nix: adds rust-src as an extension to all channels

### DIFF
--- a/rust-src-overlay.nix
+++ b/rust-src-overlay.nix
@@ -1,0 +1,18 @@
+# Overlay that builds on top of rust-overlay.nix.
+# Adds rust-src component to all channels which is helpful for racer, intellij, ...
+
+self: super:
+
+let mapAttrs = super.stdenv.lib.mapAttrs;
+    flip = super.stdenv.lib.flip;
+in {
+  # install stable rust with rust-src:
+  # "nix-env -i -A nixos.latest.rustChannels.stable.rust"
+
+  latest.rustChannels =
+    flip mapAttrs super.latest.rustChannels (name: value: value // {
+      rust = value.rust.override {
+        extensions = ["rust-src"];
+      };
+    });
+}


### PR DESCRIPTION
I spent considerable time to use the overlay and install rust including rust-src via nix-env.

It seeems like the general problems is common, even though other user prefer a nix-shell environment: #51, #19

If you like this pull request, this should probably be added to the README.rst as an option.