### PR TITLE
Improve nix-shell environment for developing Gecko.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,74 @@ Example of using in ```shell.nix```:
        ];
    }
 
+Gecko Development Environment
+-----------------------------
+
+The ``firefox-overlay.nix`` provides a development environment to build Firefox
+from its sources, also known as Gecko.
+
+To build Gecko from its sources, it is best to have a local checkout of Gecko,
+and to build it with a ``nix-shell``. You can checkout Gecko, either using
+mercurial, or git.
+
+Once you have finished the checkout gecko, you should enter the ``nix-shell``
+using the ``gecko.<arch>.<cc>`` attribute of the ``release.nix`` file provided
+in this repository.
+
+The ``<arch>`` attribute is either ``x86_64-linux`` or ``i686-linux``. The first
+one would create a native toolchain for compiling on x64, while the second one
+would give a native toolchain for compiling on x86. Note that due to the size of
+the compilation units on x86, the compilation might not be able to complete, but
+some sub part of Gecko, such as SpiderMonkey would compile fine.
+
+The ``<cc>`` attribute is either ``gcc`` or ``clang``, or any specific version
+of the compiler available in the ``compiler-overlay.nix`` file which is repeated
+in ``release.nix``. This compiler would only be used for compiling Gecko, and
+the rest of the toolchain is compiled against the default ``stdenv`` of the
+architecture.
+
+When first enterring the ``nix-shell``, the toolchain will pull and build all
+the dependencies necessary to build Gecko, this includes might take some time.
+This work will not be necessary the second time, unless you use a different
+toolchain or architecture.
+
+.. code:: sh
+
+  ~/$ cd mozilla-central
+  ~/mozilla-central$ nix-shell ../nixpkgs-mozilla/release.nix -A gecko.x86_64-linux.gcc --pure
+    ... pull the rust compiler
+    ... compile the toolchain
+  [~/mozilla-central] python ./mach build
+    ... build firefox desktop
+  [~/mozilla-central] python ./mach run
+    ... run firefox
+
+When enterring the ``nix-shell``, the ``MOZCONFIG`` environment variable is set
+to a local file, named ``.mozconfig.nix-shell``, created each time you enter the
+``nix-shell``. You can create your own ``.mozconfig`` file which extends the
+default one, with your own options.
+
+.. code:: sh
+
+  ~/mozilla-central$ nix-shell ../nixpkgs-mozilla/release.nix -A gecko.x86_64-linux.gcc --pure
+  [~/mozilla-central] cat .mozconfig
+  # Import current nix-shell config.
+  . .mozconfig.nix-shell
+
+  ac_add_options --enable-js-shell
+  ac_add_options --disable-tests
+  [~/mozilla-central] export MOZCONFIG=$(pwd)/.mozconfig
+  [~/mozilla-central] python ./mach build
+
+To avoid repeating your-self, you can also rely on the ``NIX_SHELL_HOOK``
+environment variable, to reset the ``MOZCONFIG`` environment variable for you.
+
+.. code:: sh
+
+  ~/mozilla-central$ export NIX_SHELL_HOOK="export MOZCONFIG=$(pwd)/.mozconfig;"
+  ~/mozilla-central$ nix-shell ../nixpkgs-mozilla/release.nix -A gecko.x86_64-linux.gcc --pure
+  [~/mozilla-central] python ./mach build
+
 TODO
 ----
 

--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -138,7 +138,11 @@ in
   devEnv = (super.shell or {}) // {
     gecko = super.callPackage ./pkgs/gecko {
       inherit (self.pythonPackages) setuptools;
-      inherit (self.latest.rustChannels.stable) rust;
+
+      # Due to std::ascii::AsciiExt changes in 1.23, Gecko does not compile, so
+      # use the latest Rust version before 1.23.
+      rust = (super.rustChannelOf { channel = "stable"; date = "2017-11-22"; }).rust;
+      # inherit (self.latest.rustChannels.stable) rust;
     };
   };
 

--- a/pkgs/gecko/default.nix
+++ b/pkgs/gecko/default.nix
@@ -88,18 +88,18 @@ let
     cxxLib=$( echo -n ${gcc}/include/c++/* )
     archLib=$cxxLib/$( ${gcc}/bin/gcc -dumpmachine )
 
-    echo > $MOZCONFIG_TEMPLATE "
+    cat - > $MOZCONFIG <<EOF
     mk_add_options AUTOCONF=${autoconf213}/bin/autoconf
     ac_add_options --with-libclang-path=${llvmPackages.clang.cc}/lib
     ac_add_options --with-clang-path=${llvmPackages.clang}/bin/clang
-    export BINDGEN_CFLAGS=\"-cxx-isystem $cxxLib -isystem $archLib\"
+    export BINDGEN_CFLAGS="-cxx-isystem $cxxLib -isystem $archLib"
     export CC="${stdenv.cc}/bin/cc"
     export CXX="${stdenv.cc}/bin/c++"
-    "
+    EOF
   '';
 
   shellHook = ''
-    export MOZCONFIG_TEMPLATE=$PWD/.mozconfig.template
+    export MOZCONFIG=$PWD/.mozconfig.nix-shell
     export MOZBUILD_STATE_PATH=$PWD/.mozbuild
     export CC="${stdenv.cc}/bin/cc";
     export CXX="${stdenv.cc}/bin/c++";
@@ -138,14 +138,12 @@ stdenv.mkDerivation {
     export MOZBUILD_STATE_PATH=$(pwd)/.mozbuild
     export MOZCONFIG=$(pwd)/.mozconfig
     export builddir=$(pwd)/builddir
-    export MOZCONFIG_TEMPLATE=$(pwd)/.mozconfig.template
     ${genMozConfig}
 
     mkdir -p $MOZBUILD_STATE_PATH $builddir
 
-    echo > $MOZCONFIG "
+    echo >> $MOZCONFIG "
     # . $src/build/mozconfig.common
-    . $MOZCONFIG_TEMPLATE
 
     ac_add_options --enable-application=browser
     mk_add_options MOZ_OBJDIR=$builddir

--- a/pkgs/gecko/default.nix
+++ b/pkgs/gecko/default.nix
@@ -1,8 +1,9 @@
 { geckoSrc ? null, lib
 , stdenv, fetchFromGitHub, pythonFull, which, autoconf213
-, perl, unzip, zip, gnumake, yasm, pkgconfig, xlibs, gnome2, pango
+, perl, unzip, zip, gnumake, yasm, pkgconfig, xlibs, gnome2, pango, freetype, fontconfig, cairo
 , dbus, dbus_glib, alsaLib, libpulseaudio, gstreamer, gst_plugins_base
-, gtk3, glib, gobjectIntrospection, git, mercurial, openssl, cmake, procps
+, gtk3, glib, gobjectIntrospection, gdk_pixbuf, atk, gtk2
+, git, mercurial, openssl, cmake, procps
 , libnotify
 , valgrind, gdb, rr
 , setuptools
@@ -46,14 +47,15 @@ let
     gnome2.libgnome gnome2.libgnomecanvas gnome2.libgnomeui
     gnome2.libIDL
 
-    pango
+    pango freetype fontconfig cairo
 
     dbus dbus_glib
 
     alsaLib libpulseaudio
     gstreamer gst_plugins_base
 
-    gtk3 glib gobjectIntrospection
+    gtk3 glib gobjectIntrospection gdk_pixbuf atk
+    gtk2 gnome2.GConf
 
     rust
 

--- a/pkgs/gecko/default.nix
+++ b/pkgs/gecko/default.nix
@@ -104,6 +104,7 @@ let
     export CC="${stdenv.cc}/bin/cc";
     export CXX="${stdenv.cc}/bin/c++";
     ${genMozConfig}
+    ${builtins.getEnv "NIX_SHELL_HOOK"}
   '';
 
   # propagatedBuildInput should already have applied the "lib.chooseDevOutputs"

--- a/pkgs/gecko/default.nix
+++ b/pkgs/gecko/default.nix
@@ -99,9 +99,11 @@ let
   '';
 
   shellHook = ''
+    export MOZCONFIG_TEMPLATE=$PWD/.mozconfig.template
     export MOZBUILD_STATE_PATH=$PWD/.mozbuild
     export CC="${stdenv.cc}/bin/cc";
     export CXX="${stdenv.cc}/bin/c++";
+    ${genMozConfig}
   '';
 
   # propagatedBuildInput should already have applied the "lib.chooseDevOutputs"


### PR DESCRIPTION
Fix:
 - Pin rustc version to avoid error during webrender / stylo compilations.
 - bindgen arguments are now provided to the shell throught the $MOZCONFIG_TEMPLATE, this ensure that stylo compilation works.
 - clang is removes from the list of dependencies in order to avoid confusing the toolchain. Instead, clang arguments for bindgen are provided in the $MOZCONFIG_TEMPLATE file.
 - Add missing dependencies reported by the configure phase.

New feature:
 - NIX_SHELL_HOOK environment variable can be use to avoid repeating your-self on the command line. Thus, one can define this variable with some script content, which exports a bunch of environment variables such as MOZ_LOG and others.
 - Proper README.rst documentation.

Edit: remove comment about unset-ing noisy environment variables.
Edit: Add an entry in the README.