### PR TITLE
Fix gecko build.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@ with super.lib;
 
   (import ./lib-overlay.nix)
   (import ./rust-overlay.nix)
+  (import ./rr-overlay.nix)
   (import ./firefox-overlay.nix)
   (import ./vidyo-overlay.nix)
   (import ./servo-overlay.nix)

--- a/pkgs/gecko/default.nix
+++ b/pkgs/gecko/default.nix
@@ -90,7 +90,7 @@ let
 
     cat - > $MOZCONFIG <<EOF
     mk_add_options AUTOCONF=${autoconf213}/bin/autoconf
-    ac_add_options --with-libclang-path=${llvmPackages.clang.cc}/lib
+    ac_add_options --with-libclang-path=${llvmPackages.clang.cc.lib}/lib
     ac_add_options --with-clang-path=${llvmPackages.clang}/bin/clang
     export BINDGEN_CFLAGS="-cxx-isystem $cxxLib -isystem $archLib"
     export CC="${stdenv.cc}/bin/cc"

--- a/rr-overlay.nix
+++ b/rr-overlay.nix
@@ -1,0 +1,14 @@
+self: super:
+
+{
+  # Add i686-linux platform as a valid target.
+  rr = super.rr.override {
+    stdenv = self.stdenv // {
+      mkDerivation = args: self.stdenv.mkDerivation (args // {
+        meta = args.meta // {
+          platforms = self.stdenv.lib.platforms.linux;
+        };
+      });
+    };
+  };
+}


### PR DESCRIPTION
Gecko now requires a recent version of gcc, which implies that we have to bump nixpkgs locally, and follow the multiple output changes of libclang. Also, rr no longer contains x86 platform which is a bug in nixpkgs, but to work with old nixpkgs version, I prefer to push this work-around here in the mean time.
