### PR TITLE
VidyoDesktop requires libGL on unstable

### DIFF
--- a/pkgs/VidyoDesktop/default.nix
+++ b/pkgs/VidyoDesktop/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, buildFHSUserEnv, makeWrapper, dpkg, alsaLib,
-  alsaUtils, alsaOss, alsaTools, alsaPlugins, libidn, utillinux, mesa_glu, qt4,
+  alsaUtils, alsaOss, alsaTools, alsaPlugins, libidn, libGL, utillinux, mesa_glu, qt4,
   zlib, patchelf, xorg, libpulseaudio
 }:
 
@@ -23,7 +23,7 @@ in buildFHSUserEnv {
   targetPkgs = pkgs: [ VidyoDesktopDeb ];
   multiPkgs = pkgs: [
     patchelf dpkg alsaLib alsaUtils alsaOss alsaTools alsaPlugins
-    libidn utillinux mesa_glu qt4 zlib xorg.libXext xorg.libXv xorg.libX11
+    libidn libGL utillinux mesa_glu qt4 zlib xorg.libXext xorg.libXv xorg.libX11
     xorg.libXfixes xorg.libXrandr xorg.libXScrnSaver
     libpulseaudio
   ];


### PR DESCRIPTION
Thanks to @washort for telling me how to get it running again.