### PR TITLE
Update gecko build environment.

### DIFF
--- a/compilers-overlay.nix
+++ b/compilers-overlay.nix
@@ -76,6 +76,8 @@ let
     clang37 = llvmPackages_37;
     clang38 = llvmPackages_38; # not working yet.
     gcc = gcc;
+    gcc6 = gcc6;
+    gcc5 = gcc5;
     gcc49 = gcc49;
     gcc48 = gcc48;
     gcc474 = chgCompilerSource gcc473 "gcc-4.7.4" (fetchurl {

--- a/compilers-overlay.nix
+++ b/compilers-overlay.nix
@@ -35,10 +35,12 @@ let
   # latest header files from GCC, which are not supported by clang, because
   # clang implement a different set of locking primitives than GCC.  This
   # expression is used to wrap clang with a matching verion of the libc++.
-  maybeWrapClang = cc:
+  maybeWrapClang = cc: cc;
+  /*
     if cc ? clang
     then clangWrapCC cc
     else cc;
+    */
 
   clangWrapCC = llvmPackages:
     let libcxx =
@@ -62,6 +64,7 @@ let
 
   buildWithCompiler = cc:
     super.stdenvAdapters.overrideCC self.stdenv (maybeWrapClang cc);
+
   chgCompilerSource = cc: name: src:
     cc.override (conf:
       if conf ? gcc then # Nixpkgs 14.12
@@ -71,10 +74,10 @@ let
     );
 
   compilersByName = with self; {
-    clang = llvmPackages;
-    clang36 = llvmPackages_36;
-    clang37 = llvmPackages_37;
-    clang38 = llvmPackages_38; # not working yet.
+    clang = llvmPackages.clang;
+    clang36 = llvmPackages_36.clang;
+    clang37 = llvmPackages_37.clang;
+    clang38 = llvmPackages_38.clang; # not working yet.
     gcc = gcc;
     gcc6 = gcc6;
     gcc5 = gcc5;

--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -151,8 +151,8 @@ in
   # Set of packages which used to build developer environment
   devEnv = (super.shell or {}) // {
     gecko = super.callPackage ./pkgs/gecko {
-      inherit (self.python3Packages) setuptools;
-      pythonFull = self.python3Full;
+      inherit (self.python35Packages) setuptools;
+      pythonFull = self.python35Full;
 
       # Due to std::ascii::AsciiExt changes in 1.23, Gecko does not compile, so
       # use the latest Rust version before 1.23.

--- a/pkgs/gecko/default.nix
+++ b/pkgs/gecko/default.nix
@@ -11,6 +11,8 @@
 , buildFHSUserEnv # Build a FHS environment with all Gecko dependencies.
 , llvmPackages
 , ccache
+
+, zlib, xorg
 }:
 
 let
@@ -112,14 +114,15 @@ let
   pullAllInputs = inputs:
     inputs ++ lib.concatMap (i: pullAllInputs (i.propagatedNativeBuildInputs or [])) inputs;
 
-  fhs = buildFHSUserEnv {
+  fhs = buildFHSUserEnv rec {
     name = "gecko-deps-fhs";
-    targetPkgs = _: pullAllInputs (lib.chooseDevOutputs (buildInputs ++ [ stdenv.cc ]));
-    multiPkgs = null;
+    targetPkgs = _: pullAllInputs (lib.chooseDevOutputs (buildInputs ++ [ stdenv.cc zlib xorg.libXinerama xorg.libXxf86vm ]));
+    multiPkgs = null; #targetPkgs;
     extraOutputsToInstall = [ "share" ];
     profile = ''
       # build-fhs-userenv/env.nix adds it, but causes 'ls' to SEGV.
       unset LD_LIBRARY_PATH;
+      export LD_LIBRARY_PATH=/lib/;
       export IN_NIX_SHELL=1
       export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/share/pkgconfig
       ${shellHook}

--- a/release.nix
+++ b/release.nix
@@ -55,6 +55,8 @@ let
     "clang37"
     "clang38"
     "gcc"
+    "gcc6"
+    "gcc5"
     "gcc49"
     "gcc48"
     #"gcc474"


### PR DESCRIPTION
* Add newer versions of gcc to the list of compilers, for bisecting compilers.
* Downgrade to python 3.5 ( https://bugzilla.mozilla.org/show_bug.cgi?id=1465035 )
* Add missing X dependencies. ( https://bugzilla.mozilla.org/show_bug.cgi?id=1456183 )
* Fix clang compilation for SpiderMonkey (not tested on Gecko yet )