### PR TITLE
Add helper Rust builder

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -286,6 +286,11 @@ rec {
     };
   };
 
+  # Helper builder
+  rustChannelOfTargets = channel: date: targets:
+    (rustChannelOf { inherit channel date; })
+      .rust.override { inherit targets; };
+
   # For backward compatibility
   rustChannels = latest.rustChannels;
 


### PR DESCRIPTION
This helper has been requested for in `#rust-offtopic`, for using the channel generation commands easily from the command line with `nix-shell -p`.

Maybe it could even be improved by making intermediate functions derivation functors, so that arguments 2 and 3 are optional? if you think it'd be better I can try to implement it :)