### PR TITLE
Add nodejs and cbindgen dependency for building Firefox.

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -153,6 +153,9 @@ in
     gecko = super.callPackage ./pkgs/gecko {
       inherit (self.python35Packages) setuptools;
       pythonFull = self.python35Full;
+      nodejs =
+        if builtins.compareVersions self.nodejs.name "nodejs-8.11.3" < 0
+        then self.nodejs-8_x else self.nodejs;
 
       # Due to std::ascii::AsciiExt changes in 1.23, Gecko does not compile, so
       # use the latest Rust version before 1.23.
@@ -163,4 +166,8 @@ in
 
   # Set of packages which are frozen at this given revision of nixpkgs-mozilla.
   firefox-nightly-bin = super.callPackage ./pkgs/firefox-nightly-bin/default.nix { };
+
+  # Use rust-cbindgen imported from Nixpkgs (August 2018) unless the current
+  # version of Nixpkgs already packages a version of rust-cbindgen.
+  rust-cbindgen = super.rust-cbindgen or super.callPackage ./pkgs/cbindgen { };
 }

--- a/pkgs/cbindgen/default.nix
+++ b/pkgs/cbindgen/default.nix
@@ -1,0 +1,25 @@
+### NOTE: This file is imported from Nixpkgs repository (August 2018)
+### It is used as a fallback when rust-cbindgen is not provided by the
+### current version of Nixpkgs.
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "rust-cbindgen-${version}";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "eqrion";
+    repo = "cbindgen";
+    rev = "v${version}";
+    sha256 = "03qzqy3indqghqy7rnli1zrrlnyfkygxjpb2s7041cik54kf2krw";
+  };
+
+  cargoSha256 = "0c3xpzff8jldqbn5a25yy6c2hlz5xy636ml6sj5d24wzcgwg5a2i";
+
+  meta = with stdenv.lib; {
+    description = "A project for generating C bindings from Rust code";
+    homepage = https://github.com/eqrion/cbindgen;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/gecko/default.nix
+++ b/pkgs/gecko/default.nix
@@ -13,6 +13,8 @@
 , ccache
 
 , zlib, xorg
+, rust-cbindgen
+, nodejs
 }:
 
 let
@@ -81,6 +83,12 @@ let
 
     # Useful for getting notification at the end of the build.
     libnotify
+
+    # cbindgen is used to generate C bindings for WebRender.
+    rust-cbindgen
+
+    # NodeJS is used for tooling around JS development.
+    nodejs
 
   ] ++ optionals inNixShell [
     valgrind gdb rr ccache


### PR DESCRIPTION
This pull request adds nodejs and cbindgen dependencies to gecko dev environment.

Unfortunately, nixos-18.03 does not have `nodejs-8_x` as the default, and not does include `rust-cbindgen` yet, as opposed to nixos-unstable. Therefore, this commit does a bit of work-around to work on top of nixos-18.03 by importing them from Nixpkgs, or comparing the versions to check if we have the desired version or not.
