### PR TITLE
Fix rust-cbindgen expression.

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -169,5 +169,5 @@ in
 
   # Use rust-cbindgen imported from Nixpkgs (August 2018) unless the current
   # version of Nixpkgs already packages a version of rust-cbindgen.
-  rust-cbindgen = super.rust-cbindgen or super.callPackage ./pkgs/cbindgen { };
+  rust-cbindgen = super.rust-cbindgen or (super.callPackage ./pkgs/cbindgen { });
 }


### PR DESCRIPTION
This does not evaluate properly without this as I get:

```
error: attempt to call something which is not a function but a set
```

I'm no expert but it would seem there is a precedence issue in the expression as it was written.