### PR TITLE
Allow usage as package set instead of overlay

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,14 +4,6 @@ self: super:
 
 with super.lib;
 
-(foldl' (flip extends) (_: super) [
-
-  (import ./lib-overlay.nix)
-  (import ./rust-overlay.nix)
-  (import ./rr-overlay.nix)
-  (import ./firefox-overlay.nix)
-  (import ./vidyo-overlay.nix)
-  (import ./servo-overlay.nix)
-  (import ./git-cinnabar-overlay.nix)
-
-]) self
+(foldl' (flip extends) (_: super)
+  (map import (import ./overlays.nix)))
+  self

--- a/overlays.nix
+++ b/overlays.nix
@@ -1,0 +1,9 @@
+[
+  ./lib-overlay.nix
+  ./rust-overlay.nix
+  ./rr-overlay.nix
+  ./firefox-overlay.nix
+  ./vidyo-overlay.nix
+  ./servo-overlay.nix
+  ./git-cinnabar-overlay.nix
+]

--- a/package-set.nix
+++ b/package-set.nix
@@ -1,0 +1,8 @@
+{ pkgs }:
+
+with pkgs.lib;
+let
+  self = foldl'
+    (prev: overlay: prev // (overlay (pkgs // self) (pkgs // prev)))
+    {} (map import (import ./overlays.nix));
+in self


### PR DESCRIPTION
This extracts the overlays list, to be used by both the combined
overlay and the package set representation.

It is meant to be used with nix-community/NUR#32