### PR TITLE
Bumps cbindgen to 0.6.2

### DIFF
--- a/pkgs/cbindgen/default.nix
+++ b/pkgs/cbindgen/default.nix
@@ -5,13 +5,13 @@
 
 rustPlatform.buildRustPackage rec {
   name = "rust-cbindgen-${version}";
-  version = "0.6.1";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "eqrion";
     repo = "cbindgen";
     rev = "v${version}";
-    sha256 = "03qzqy3indqghqy7rnli1zrrlnyfkygxjpb2s7041cik54kf2krw";
+    sha256 = "0hifmn9578cf1r5m4ajazg3rhld2ybd2v48xz04vfhappkarv4w2";
   };
 
   cargoSha256 = "0c3xpzff8jldqbn5a25yy6c2hlz5xy636ml6sj5d24wzcgwg5a2i";


### PR DESCRIPTION
* [x] Bump cbindgen version to 0.6.2 in accordance with [bug 1485197](https://bugzilla.mozilla.org/show_bug.cgi?id=1485197).
* [ ] Use rustc 1.26.0 or higher to compile cbindgen.