### PR TITLE
Add 2 environment variables for compiling the JS Shell with Cranelift.

### DIFF
--- a/pkgs/gecko/default.nix
+++ b/pkgs/gecko/default.nix
@@ -113,6 +113,11 @@ let
     export MOZBUILD_STATE_PATH=$PWD/.mozbuild
     export CC="${stdenv.cc}/bin/cc";
     export CXX="${stdenv.cc}/bin/c++";
+    # To be used when building the JS Shell.
+    export NIX_EXTRA_CONFIGURE_ARGS="--with-libclang-path=${llvmPackages.clang.cc.lib}/lib --with-clang-path=${llvmPackages.clang}/bin/clang"
+    cxxLib=$( echo -n ${gcc}/include/c++/* )
+    archLib=$cxxLib/$( ${gcc}/bin/gcc -dumpmachine )
+    export BINDGEN_CFLAGS="-cxx-isystem $cxxLib -isystem $archLib"
     ${genMozConfig}
     ${builtins.getEnv "NIX_SHELL_HOOK"}
   '';


### PR DESCRIPTION
This patch is used to expose clang and bindgen configs to be used on the command line, when building the JS Shell with its configure script.