### PR TITLE
Update git-cinnabar to 0.5.0

### DIFF
--- a/pkgs/git-cinnabar/default.nix
+++ b/pkgs/git-cinnabar/default.nix
@@ -3,6 +3,7 @@
 , python
 , perl
 , gettext
+, git
 , mercurial
 }:
 
@@ -12,7 +13,7 @@
 # NOTE: This package only provides git-cinnabar tools, as a git users might want
 # to have additional commands not provided by this forked version of git-core.
 stdenv.mkDerivation rec {
-  version = "0.5.0b3";
+  version = "0.5.0";
   name = "git-cinnabar-${version}";
   src = fetchFromGitHub {
     owner = "glandium";
@@ -20,9 +21,9 @@ stdenv.mkDerivation rec {
     inherit name;
     rev = version; # tag name
     fetchSubmodules = true;
-    sha256 = "02fl3lzf7cnns88pkc8npr77dd7mm38h859q0fimgd21gw84xj01";
+    sha256 = "1yki44qzh3ca41xv4ch3fkxalsj707q2az0yjb917q3mpavxsx9q";
   };
-  buildInputs = [ autoconf python gettext ];
+  buildInputs = [ autoconf python gettext git ];
 
   ZLIB_PATH = zlib;
   ZLIB_DEV_PATH = zlib.dev;
@@ -36,6 +37,10 @@ stdenv.mkDerivation rec {
     export ZLIB_DEV_PATH;
     substituteInPlace git-core/Makefile --replace \
       '$(ZLIB_PATH)/include' '$(ZLIB_DEV_PATH)/include'
+    # Comment out calls to git to try to verify that git-core is up to date
+    substituteInPlace Makefile \
+      --replace '$(eval $(call exec,git' '# $(eval $(call exec,git'
+
 
     export PERL_PATH;
     export NO_TCLTK
@@ -43,6 +48,8 @@ stdenv.mkDerivation rec {
   '';
 
   makeFlags = "prefix=\${out}";
+
+  installTargets = "git-install";
 
   postInstall =
     let mercurial-py = mercurial + "/" + mercurial.python.sitePackages; in ''


### PR DESCRIPTION
git-cinnabar 0.5.0 was released on August 11. https://github.com/glandium/git-cinnabar/releases/tag/0.5.0

There were some changes to the Makefile that I try to work around here:

- [Try to make sure that git-core submodule is up to date](https://github.com/glandium/git-cinnabar/commit/5cf2df3ffe4f33674719064953bd5ac568404794). Add git to the build-inputs so some of these calls succeed, but then comment out most of the actual work that would happen to do the update. We have `fetchSubmodules=true` so there's no real need for it anyhow.
- [Change the default build rule when running plain `make`](https://github.com/glandium/git-cinnabar/commit/2a327c003d6af49f62fac508cdc4781cece0bcea#diff-b67911656ef5d18c4ae36cb6741b7965). To be honest I'm not sure if I'm handling this correctly, but just doing `make install` now fails.