### PR TITLE
Upgrade rust-cbindgen

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -158,9 +158,9 @@ in
         then self.nodejs-8_x else self.nodejs;
 
       rust-cbindgen =
-        if !(self ? "rust-cbindgen") then self.rust-cbindgen-0_6_2
-        else if builtins.compareVersions self.rust-cbindgen.name "rust-cbindgen-0.6.2" < 0
-        then self.rust-cbindgen-0_6_2 else self.rust-cbindgen;
+        if !(self ? "rust-cbindgen") then self.rust-cbindgen-latest
+        else if builtins.compareVersions self.rust-cbindgen.name "rust-cbindgen-0.6.4" < 0
+        then self.rust-cbindgen-latest else self.rust-cbindgen;
 
       # Due to std::ascii::AsciiExt changes in 1.23, Gecko does not compile, so
       # use the latest Rust version before 1.23.
@@ -174,7 +174,7 @@ in
 
   # Use rust-cbindgen imported from Nixpkgs (September 2018) unless the current
   # version of Nixpkgs already packages a version of rust-cbindgen.
-  rust-cbindgen-0_6_2 = super.callPackage ./pkgs/cbindgen {
+  rust-cbindgen-latest = super.callPackage ./pkgs/cbindgen {
     rustPlatform = super.makeRustPlatform {
       cargo = self.latest.rustChannels.stable.rust;
       rustc = self.latest.rustChannels.stable.rust;

--- a/pkgs/cbindgen/default.nix
+++ b/pkgs/cbindgen/default.nix
@@ -1,20 +1,20 @@
-### NOTE: This file is imported from Nixpkgs repository (August 2018)
-### It is used as a fallback when rust-cbindgen is not provided by the
-### current version of Nixpkgs.
+### NOTE: This file is a copy of the one from Nixpkgs repository
+### (taken 2018 October).  It is used when the version of cbindgen in
+### upstream nixpkgs is not up-to-date enough to compile Firefox.
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
   name = "rust-cbindgen-${version}";
-  version = "0.6.2";
+  version = "0.6.6";
 
   src = fetchFromGitHub {
     owner = "eqrion";
     repo = "cbindgen";
     rev = "v${version}";
-    sha256 = "0hifmn9578cf1r5m4ajazg3rhld2ybd2v48xz04vfhappkarv4w2";
+    sha256 = "12s4lps8p6hrxvki9a5dxzbmxsddvkm6ias3n4daa1s3bncd86zk";
   };
 
-  cargoSha256 = "0c3xpzff8jldqbn5a25yy6c2hlz5xy636ml6sj5d24wzcgwg5a2i";
+  cargoSha256 = "137dqj1sp02dh0dz9psf8i8q57gmz3rfgmwk073k7x5zzkgvj21c";
 
   meta = with stdenv.lib; {
     description = "A project for generating C bindings from Rust code";


### PR DESCRIPTION
As of https://bugzilla.mozilla.org/show_bug.cgi?id=1496486, Firefox now requires cbindgen 0.6.4 to build.