### PR TITLE
rust-overlay: fixing the latest nightly Rusts

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -142,6 +142,7 @@ let
           # This code is inspired by patchelf/setup-hook.sh to iterate over all binaries.
           installPhase = ''
             patchShebangs install.sh
+            sed -i "s/llvm-tools-preview//" components
             CFG_DISABLE_LDCONFIG=1 ./install.sh --prefix=$out --verbose
 
             setInterpreter() {


### PR DESCRIPTION
The Rust overlay didn't work with the latest nightly Rusts, because of a faulty "component". This fixes it, at least temporarily. Incidentally, this also fixes #92, because the latest nightly Rust have apparently fixed the toolchain.

Once this gets merged, we'll be just one step away from Rust-WASM Nix expression to use instead of the current NPM-based pipeline.