### PR TITLE
Change Vidyo URL

### DIFF
--- a/pkgs/VidyoDesktop/default.nix
+++ b/pkgs/VidyoDesktop/default.nix
@@ -15,7 +15,7 @@ let
     builder = ./builder.sh;
     inherit dpkg;
     src = fetchurl {
-      url = "https://vidyoportal.cern.ch/upload/VidyoDesktopInstaller-ubuntu64-TAG_VD_${vidyoVersionUnderscore}_${vidyoBuild}.deb";
+      url = "https://client-downloads.vidyocloud.com/VidyoDesktopInstaller-ubuntu64-TAG_VD_${vidyoVersionUnderscore}_${vidyoBuild}.deb";
       sha256 = "01spq6r49myv82fdimvq3ykwb1lc5bymylzcydfdp9xz57f5a94x";
     };
     buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Instead of using a 3rd party URL, we can use Vidyo's server.