### PR TITLE
Bump cbindgen to 0.6.7

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -159,7 +159,7 @@ in
 
       rust-cbindgen =
         if !(self ? "rust-cbindgen") then self.rust-cbindgen-latest
-        else if builtins.compareVersions self.rust-cbindgen.name "rust-cbindgen-0.6.4" < 0
+        else if builtins.compareVersions self.rust-cbindgen.version "0.6.7" < 0
         then self.rust-cbindgen-latest else self.rust-cbindgen;
 
       # Due to std::ascii::AsciiExt changes in 1.23, Gecko does not compile, so

--- a/pkgs/cbindgen/default.nix
+++ b/pkgs/cbindgen/default.nix
@@ -5,13 +5,13 @@
 
 rustPlatform.buildRustPackage rec {
   name = "rust-cbindgen-${version}";
-  version = "0.6.6";
+  version = "0.6.7";
 
   src = fetchFromGitHub {
     owner = "eqrion";
     repo = "cbindgen";
     rev = "v${version}";
-    sha256 = "12s4lps8p6hrxvki9a5dxzbmxsddvkm6ias3n4daa1s3bncd86zk";
+    sha256 = "0sgkgvkqrc6l46fvk6d9hsy0xrjpl2ix47f3cv5bi74dv8i4y2b4";
   };
 
   cargoSha256 = "137dqj1sp02dh0dz9psf8i8q57gmz3rfgmwk073k7x5zzkgvj21c";


### PR DESCRIPTION
This is required now since
https://bugzilla.mozilla.org/show_bug.cgi?id=1503401.

While we're here, rewrite the version-checking logic to simplify.