### PR TITLE
Don't "build" Rust packages on a remote builder

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -138,6 +138,11 @@ let
         stdenv.mkDerivation {
           inherit name;
           inherit src;
+
+          # No point copying src to a build server, then copying back the
+          # entire unpacked contents after just a little twiddling.
+          preferLocalBuild = true;
+
           # (@nbp) TODO: Check on Windows and Mac.
           # This code is inspired by patchelf/setup-hook.sh to iterate over all binaries.
           installPhase = ''


### PR DESCRIPTION
There's no point copying the src tarball to a remote build server, then copying back the entire unpacked contents after just a little twiddling.

This makes builds significantly faster for those of us with remote builders configured, since the network transfers can be much slower than the actual derivation build step.