### PR TITLE
Accept TOML list in fromTOML function

### DIFF
--- a/lib/parseTOML.nix
+++ b/lib/parseTOML.nix
@@ -4,7 +4,7 @@ with builtins;
 let
   layout_pat = "[ \n]+";
   layout_pat_opt = "[ \n]*";
-  token_pat = ''=|[[][[][a-zA-Z0-9_."*-]+[]][]]|[[][a-zA-Z0-9_."*-]+[]]|[a-zA-Z0-9_-]+|"[^"]*"''; #"
+  token_pat = ''=|[[][[][a-zA-Z0-9_."*-]+[]][]]|[[][a-zA-Z0-9_."*-]+[]]|[[][^]]+[]]|[a-zA-Z0-9_-]+|"[^"]*"''; #"
 
   tokenizer_1_11 = str:
     let
@@ -124,6 +124,8 @@ let
   tokenToValue = token:
     if token == "true" then true
     else if token == "false" then false
+    # TODO: convert the TOML list into a Nix list.
+    else if match "[[][^]]+[]]" token != null then token
     else unescapeString token;
 
   parserInitState = {


### PR DESCRIPTION
This fix is taken from @spacefrogg solution described in https://github.com/mozilla/nixpkgs-mozilla/issues/148#issuecomment-455314172 and to which I added a way to avoid crashing if the value is ever read afterwards.

We should probably use `fromJSON` to decode the TOML list into a Nix list, if we want to use the list of profile as well to better mimic `rustup`.
