### PR TITLE
Do not add an unnecessary dependency on stdc++

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -162,7 +162,6 @@ let
                 echo "setting interpreter of $i"
                 patchelf \
                   --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-                  --add-needed ${stdenv.cc.cc.lib}/lib/libstdc++.so.6 \
                   "$i" || true
               done < <(find "$dir" -type f -print0)
             }


### PR DESCRIPTION
It crashes the compiler.

Fixes #152 