### PR TITLE
Gecko: Add llvm dependency for llvm-objdump.

### DIFF
--- a/pkgs/gecko/default.nix
+++ b/pkgs/gecko/default.nix
@@ -9,7 +9,7 @@
 , setuptools
 , rust # rust & cargo bundled. (otheriwse use pkgs.rust.{rustc,cargo})
 , buildFHSUserEnv # Build a FHS environment with all Gecko dependencies.
-, llvmPackages, nasm
+, llvm, llvmPackages, nasm
 , ccache
 
 , zlib, xorg
@@ -71,6 +71,7 @@ let
     # the choices of the compilers.
 
     # clang
+    llvm
 
     # mach mochitest
     procps


### PR DESCRIPTION
llvm-objdump is now required for building Gecko. It was supposed to be available already as it is packaged with llvm-config, but llvm-config was not used as it could not provide clang information.