### PR TITLE
cbindgen: 0.6.7 -> 0.6.8

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -163,7 +163,7 @@ in
 
       rust-cbindgen =
         if !(self ? "rust-cbindgen") then self.rust-cbindgen-latest
-        else if builtins.compareVersions self.rust-cbindgen.version "0.6.7" < 0
+        else if builtins.compareVersions self.rust-cbindgen.version self.rust-cbindgen-latest.version < 0
         then self.rust-cbindgen-latest else self.rust-cbindgen;
 
       # Due to std::ascii::AsciiExt changes in 1.23, Gecko does not compile, so

--- a/pkgs/cbindgen/default.nix
+++ b/pkgs/cbindgen/default.nix
@@ -5,16 +5,16 @@
 
 rustPlatform.buildRustPackage rec {
   name = "rust-cbindgen-${version}";
-  version = "0.6.7";
+  version = "0.6.8";
 
   src = fetchFromGitHub {
     owner = "eqrion";
     repo = "cbindgen";
     rev = "v${version}";
-    sha256 = "0sgkgvkqrc6l46fvk6d9hsy0xrjpl2ix47f3cv5bi74dv8i4y2b4";
+    sha256 = "0qjdccpyv3lkhnh3f5nzarbdc46hg0c6pmpj0x7sfdm22vbr85w5";
   };
 
-  cargoSha256 = "137dqj1sp02dh0dz9psf8i8q57gmz3rfgmwk073k7x5zzkgvj21c";
+  cargoSha256 = "1s12xn4xbxq422wgafxdb9nll0lk65wa6x3acicx5pj1y5ijjmmw";
 
   meta = with stdenv.lib; {
     description = "A project for generating C bindings from Rust code";


### PR DESCRIPTION
Bump cbindgen version for Gecko development.