### PR TITLE
Fix #152 - Rust: Remove add-needed libstdc++ line.

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -162,7 +162,6 @@ let
                 echo "setting interpreter of $i"
                 patchelf \
                   --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-                  --add-needed ${stdenv.cc.cc.lib}/lib/libstdc++.so.6 \
                   "$i" || true
               done < <(find "$dir" -type f -print0)
             }


### PR DESCRIPTION
Thanks @bbigras for the report at https://github.com/rust-lang/rust/issues/57518 and @nagisa for the fix which is implemented in this patch.