### PR TITLE
Gecko dev: Make a working dev-env on ARM64.

### DIFF
--- a/pkgs/gecko/default.nix
+++ b/pkgs/gecko/default.nix
@@ -95,7 +95,8 @@ let
     nodejs
 
   ] ++ optionals inNixShell [
-    valgrind gdb rr ccache
+    valgrind gdb ccache
+    (if stdenv.isAarch64 then null else rr)
   ];
 
   genMozConfig = ''

--- a/release.nix
+++ b/release.nix
@@ -1,6 +1,8 @@
 # To pin a specific version of nixpkgs, change the nixpkgsSrc argument.
 { nixpkgsSrc ? <nixpkgs>
-, supportedSystems ? [ "x86_64-linux" "i686-linux" /* "x86_64-darwin" */ ]
+, supportedSystems ? [ "x86_64-linux" "i686-linux" /* "x86_64-darwin" */
+    "aarch64-linux"
+  ]
 }:
 
 let


### PR DESCRIPTION
This patch ensure that the release.nix script can produce a build environment which is working well on ARM64 systems.