### PR TITLE
vidyo: fix to vidyo work with current nixos unstable

### DIFF
--- a/pkgs/VidyoDesktop/builder.sh
+++ b/pkgs/VidyoDesktop/builder.sh
@@ -6,6 +6,9 @@ dpkg -x $src unpacked
 mkdir -p $out/bin
 cp -r unpacked/* $out/
 
+sed -i -e "s|\/opt\/vidyo|\/opt2\/vidyo|" $out/usr/bin/VidyoDesktop
+
+
 ln -s $out/usr/bin/VidyoDesktop $out/bin/VidyoDesktop
 touch $out/etc/issue
 

--- a/pkgs/VidyoDesktop/builder.sh
+++ b/pkgs/VidyoDesktop/builder.sh
@@ -6,7 +6,7 @@ dpkg -x $src unpacked
 mkdir -p $out/bin
 cp -r unpacked/* $out/
 
-sed -i -e "s|\/opt\/vidyo|\/opt2\/vidyo|" $out/usr/bin/VidyoDesktop
+sed -i -e "s|/opt/vidyo|$out/opt/vidyo|" $out/usr/bin/VidyoDesktop
 
 
 ln -s $out/usr/bin/VidyoDesktop $out/bin/VidyoDesktop

--- a/pkgs/VidyoDesktop/default.nix
+++ b/pkgs/VidyoDesktop/default.nix
@@ -30,9 +30,6 @@ in buildFHSUserEnv {
     xorg.libXfixes xorg.libXrandr xorg.libXScrnSaver
     libpulseaudio
   ];
-  extraBuildCommands = ''
-    ln -s ${VidyoDesktopDeb}/opt $out/opt2
-  '';
   runScript = "VidyoDesktop";
   # for debugging
   #runScript = "bash";

--- a/pkgs/VidyoDesktop/default.nix
+++ b/pkgs/VidyoDesktop/default.nix
@@ -31,7 +31,7 @@ in buildFHSUserEnv {
     libpulseaudio
   ];
   extraBuildCommands = ''
-    ln -s ${VidyoDesktopDeb}/opt $out/opt
+    ln -s ${VidyoDesktopDeb}/opt $out/opt2
   '';
   runScript = "VidyoDesktop";
   # for debugging


### PR DESCRIPTION
with latest unstable channel /opt folder (where vidyo is copied) is
ignored since there is already something there from chroot derivation.

this solution is clearly a hack and i'm open to suggestion how to fix
this properly. until then this should be good enough.