### PR TITLE
Update cbindgen to 0.8.2

### DIFF
--- a/pkgs/cbindgen/default.nix
+++ b/pkgs/cbindgen/default.nix
@@ -5,13 +5,13 @@
 
 rustPlatform.buildRustPackage rec {
   name = "rust-cbindgen-${version}";
-  version = "0.8.0";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner = "eqrion";
     repo = "cbindgen";
     rev = "v${version}";
-    sha256 = "07cizbhr02x3rh07xhs10hzzs3lmmpf61g08sa62b98cgadvs9fq";
+    sha256 = "1ck0zyhrrj61rxcmz4045m4nl04g6r971min5hz5p8cmx4h5gl9w";
   };
 
   cargoSha256 = "00j5nm491zil6kpjns31qyd6z7iqd77b5qp4h7149s70qjwfq2cb";


### PR DESCRIPTION
I'm not sure why the cargo hash didn't change.

This is the version currently required to build Firefox.