### PR TITLE
Update to cbindgen 0.8.6

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -175,7 +175,7 @@ in
       # Due to std::ascii::AsciiExt changes in 1.23, Gecko does not compile, so
       # use the latest Rust version before 1.23.
       # rust = (super.rustChannelOf { channel = "stable"; date = "2017-11-22"; }).rust;
-      inherit (self.latest.rustChannels.stable) rust;
+      inherit (self.latest.rustChannels.nightly) rust;
       valgrind = self.valgrind-3_14;
     };
   };
@@ -184,8 +184,8 @@ in
   # version of Nixpkgs already packages a version of rust-cbindgen.
   rust-cbindgen-latest = super.callPackage ./pkgs/cbindgen {
     rustPlatform = super.makeRustPlatform {
-      cargo = self.latest.rustChannels.stable.rust;
-      rustc = self.latest.rustChannels.stable.rust;
+      cargo = self.latest.rustChannels.nightly.rust;
+      rustc = self.latest.rustChannels.nightly.rust;
     };
   };
 

--- a/pkgs/cbindgen/default.nix
+++ b/pkgs/cbindgen/default.nix
@@ -5,13 +5,13 @@
 
 rustPlatform.buildRustPackage rec {
   name = "rust-cbindgen-${version}";
-  version = "0.8.2";
+  version = "0.8.6";
 
   src = fetchFromGitHub {
     owner = "eqrion";
     repo = "cbindgen";
     rev = "v${version}";
-    sha256 = "1ck0zyhrrj61rxcmz4045m4nl04g6r971min5hz5p8cmx4h5gl9w";
+    sha256 = "0krh76ng3i19q5wffym74iamyx2bg6iw941cppfzayg4k3q2ai1w";
   };
 
   cargoSha256 = "00j5nm491zil6kpjns31qyd6z7iqd77b5qp4h7149s70qjwfq2cb";


### PR DESCRIPTION
Obsoletes #172.

cbindgen 0.8.4 and up fail the tests unless using Rust Nightly; see
https://github.com/eqrion/cbindgen/issues/338.

With this patch, I hit https://gist.github.com/glasserc/ec065e3cf7706c13742dc16fb79a931b. I am filing an issue on nixpkgs now to describe that in more detail.