### PR TITLE
Workaround for the rust-installer having \cr\lf newlines.

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -146,6 +146,7 @@ let
           # (@nbp) TODO: Check on Windows and Mac.
           # This code is inspired by patchelf/setup-hook.sh to iterate over all binaries.
           installPhase = ''
+            ${self.dos2unix}/bin/dos2unix install.sh
             patchShebangs install.sh
             sed -i "s/llvm-tools-preview//" components
             CFG_DISABLE_LDCONFIG=1 ./install.sh --prefix=$out --verbose


### PR DESCRIPTION
See #183. Calls dos2unix on the installer script before installing it.