### PR TITLE
rust: set meta.platforms

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -282,6 +282,8 @@ let
             #
             # And get a fully working Rust compiler, with the stdenv linker.
             propagatedBuildInputs = [ stdenv.cc ];
+
+            meta.platforms = stdenv.lib.platforms.all;
           }
       ) { extensions = []; targets = []; targetExtensions = []; }
     );


### PR DESCRIPTION
Using nixpkgs-mozilla Rust compiler with buildRustPackage in recent
Nixpkgs versions will result in:

> error: attribute 'platforms' missing, at nixpkgs/pkgs/build-support/rust/default.nix:164:17
> (use '--show-trace' to show detailed location information)

This change fixes that error.