### PR TITLE
rust-overlay: use builtins.fromTOML if possible.

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -3,7 +3,11 @@
 self: super:
 
 let
-  fromTOML = (import ./lib/parseTOML.nix).fromTOML;
+  fromTOML =
+    # nix 2.1 added the fromTOML builtin
+    if builtins ? fromTOML
+    then builtins.fromTOML
+    else (import ./lib/parseTOML.nix).fromTOML;
 
   parseRustToolchain = file: with builtins;
     if file == null then


### PR DESCRIPTION
On lorri (https://github.com/target/lorri/)
this decreases the time to instantiate the shell
from
5.03user 0.24system 0:05.59elapsed 94%CPU
to
2.67user 0.27system 0:03.25elapsed 90%CPU

cc @nbp 