### PR TITLE
Revert "rust-overlay: fixing the latest nightly Rusts"

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -152,7 +152,6 @@ let
           # This code is inspired by patchelf/setup-hook.sh to iterate over all binaries.
           installPhase = ''
             patchShebangs install.sh
-            sed -i "s/llvm-tools-preview//" components
             CFG_DISABLE_LDCONFIG=1 ./install.sh --prefix=$out --verbose
 
             setInterpreter() {


### PR DESCRIPTION
This reverts commit a26d388082fcd470fa05e3276c9405dc306fdf16.

Resolves #181.