### PR TITLE
Update wrapFirefox call to remove name argument

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -121,7 +121,7 @@ let
       src = fetchVersion info;
     })) {
       browserName = "firefox";
-      name = "firefox-bin-${version.version}";
+      pname = "firefox-bin-${version.version}";
       desktopName = "Firefox";
     };
 in

--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -121,7 +121,7 @@ let
       src = fetchVersion info;
     })) {
       browserName = "firefox";
-      pname = "firefox-bin-${version.version}";
+      pname = "firefox-bin";
       desktopName = "Firefox";
     };
 in


### PR DESCRIPTION
The `name` argument has been removed from the Firefox wrapper in the master version of nixpkgs:

 https://github.com/NixOS/nixpkgs/commit/d34d84a61da7cf332e470b65ab05f2d995026090

This causes the overlay to fail with the following error:

```
error: 'wrapper' at /nix/store/2h5z1dm03waymz8b383szl5bc8a21f74-nixos-20.03pre203172.0ee0489d42e/nixos/pkgs/applications/networking/browsers/firefox/wrapper.nix:21:5 called with unexpected argument 'name', at /nix/store/2h5z1dm03waymz8b383szl5bc8a21f74-nixos-20.03pre203172.0ee0489d42e/nixos/lib/customisation.nix:69:16
```

I have replaced it with `pname` in this PR.