### PR TITLE
firefox: get rid of name argument

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -121,7 +121,7 @@ let
       src = fetchVersion info;
     })) {
       browserName = "firefox";
-      name = "firefox-bin-${version.version}";
+      pname = "firefox-bin";
       desktopName = "Firefox";
     };
 in


### PR DESCRIPTION
This broke because of
https://github.com/NixOS/nixpkgs/commit/d34d84a61da7cf332e470b65ab05f2d995026090.

See https://github.com/mozilla/nixpkgs-mozilla/issues/208.