### PR TITLE
firefox-overlay: fix wrapper usage

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -121,7 +121,7 @@ let
       src = fetchVersion info;
     })) {
       browserName = "firefox";
-      name = "firefox-bin-${version.version}";
+      pname = "firefox-bin";
       desktopName = "Firefox";
     };
 in


### PR DESCRIPTION
respond to this change in nixpkgs: https://github.com/NixOS/nixpkgs/commit/d34d84a61da7cf332e470b65ab05f2d995026090

(This, when combined with disabling signature checks, allows users of the overlay to install current builds again, as of writing this comment.)