### PR TITLE
rust-overlay: support rust-toolchain file without archive date

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,24 +62,13 @@ Example of using in ```shell.nix```:
    stdenv.mkDerivation {
      name = "moz_overlay_shell";
      buildInputs = [
+       # to use the latest nightly:
        nixpkgs.latest.rustChannels.nightly.rust
-       ];
-   }
-
-Or to retrieve a specific nightly version:
-
-.. code:: nix
-
- let
-   moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
-   nixpkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
- in
-   with nixpkgs;
-   stdenv.mkDerivation {
-     name = "moz_overlay_shell";
-     buildInputs = [
+       # to use a specific nighly:
        (nixpkgs.rustChannelOf { date = "2018-04-11"; channel = "nightly"; }).rust
-       ];
+       # to use the project's rust-toolchain file:
+       (nixpkgs.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust
+     ];
    }
 
 Firefox Development Environment


### PR DESCRIPTION
This changes the parsing of a rust-toolchain file, so that specifications like `"nightly"` or `"1.34.0"` are actually accepted.