### PR TITLE
initial flake support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,11 @@
+{
+    "inputs": {
+        "nixpkgs": {
+            "inputs": {},
+            "narHash": "sha256-rgi0ELsBOtvjszaEkjz4/3fSeDJbIpiwXTgXAEHdVAE=",
+            "originalUrl": "nixpkgs",
+            "url": "github:edolstra/nixpkgs/c08930874a37d5dea5985498d4ff6dec7e9069cc"
+        }
+    },
+    "version": 3
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "Mozilla related nixpkgs";
+
+  edition = 201909;
+
+  outputs = { self, nixpkgs }:
+    let overlays = import ./overlays.nix;
+    in {
+
+      overlays = let
+        inherit (builtins) listToAttrs;
+        inherit (nixpkgs.lib) nameValuePair removeSuffix;
+
+        nvPairs = map (overlay:
+          nameValuePair
+          (removeSuffix "-overlay.nix" "${baseNameOf (toString overlay)}")
+          (import overlay)) overlays;
+
+        overlayAttrs = listToAttrs nvPairs;
+
+      in overlayAttrs;
+
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,10 @@
   edition = 201909;
 
   outputs = { self, nixpkgs }:
-    let overlays = import ./overlays.nix;
+    let
+      system = "x86_64-linux";
+      overlays = import ./overlays.nix;
+      pkgs = import nixpkgs { inherit system; };
     in {
 
       overlays = let
@@ -19,6 +22,8 @@
         overlayAttrs = listToAttrs nvPairs;
 
       in overlayAttrs;
+
+      packages."${system}" = import ./package-set.nix { inherit pkgs; };
 
     };
 }

--- a/git-cinnabar-overlay.nix
+++ b/git-cinnabar-overlay.nix
@@ -1,9 +1,9 @@
-self: super:
+final: prev:
 
 {
-  git-cinnabar = super.callPackage ./pkgs/git-cinnabar {
+  git-cinnabar = prev.callPackage ./pkgs/git-cinnabar {
     # we need urllib to recognize ssh.
-    # python = self.pythonFull;
-    python = self.mercurial.python;
+    # python = final.pythonFull;
+    python = final.mercurial.python;
   };
 }

--- a/lib-overlay.nix
+++ b/lib-overlay.nix
@@ -1,5 +1,5 @@
-self: super:
+final: prev:
 
 {
-  lib = super.lib // (import ./pkgs/lib/default.nix { pkgs = self; });
+  lib = prev.lib // (import ./pkgs/lib/default.nix { pkgs = final; });
 }

--- a/phlay-overlay.nix
+++ b/phlay-overlay.nix
@@ -1,5 +1,5 @@
-self: super:
+final: prev:
 
 {
-  phlay = super.callPackage ./pkgs/phlay {};
+  phlay = prev.callPackage ./pkgs/phlay {};
 }

--- a/rr-overlay.nix
+++ b/rr-overlay.nix
@@ -1,12 +1,12 @@
-self: super:
+final: prev:
 
 {
   # Add i686-linux platform as a valid target.
-  rr = super.rr.override {
-    stdenv = self.stdenv // {
-      mkDerivation = args: self.stdenv.mkDerivation (args // {
+  rr = prev.rr.override {
+    stdenv = final.stdenv // {
+      mkDerivation = args: final.stdenv.mkDerivation (args // {
         meta = args.meta // {
-          platforms = self.stdenv.lib.platforms.linux;
+          platforms = final.stdenv.lib.platforms.linux;
         };
       });
     };

--- a/rust-src-overlay.nix
+++ b/rust-src-overlay.nix
@@ -1,16 +1,16 @@
 # Overlay that builds on top of rust-overlay.nix.
 # Adds rust-src component to all channels which is helpful for racer, intellij, ...
 
-self: super:
+final: prev:
 
-let mapAttrs = super.stdenv.lib.mapAttrs;
-    flip = super.stdenv.lib.flip;
+let mapAttrs = prev.stdenv.lib.mapAttrs;
+    flip = prev.stdenv.lib.flip;
 in {
   # install stable rust with rust-src:
   # "nix-env -i -A nixos.latest.rustChannels.stable.rust"
 
   latest.rustChannels =
-    flip mapAttrs super.latest.rustChannels (name: value: value // {
+    flip mapAttrs prev.latest.rustChannels (name: value: value // {
       rust = value.rust.override {
         extensions = ["rust-src"];
       };

--- a/vidyo-overlay.nix
+++ b/vidyo-overlay.nix
@@ -1,5 +1,5 @@
-self: super:
+final: prev:
 
 {
-  VidyoDesktop = super.callPackage ./pkgs/VidyoDesktop { };
+  VidyoDesktop = prev.callPackage ./pkgs/VidyoDesktop { };
 }


### PR DESCRIPTION
This pr introduces initial [flake](https://github.com/tweag/rfcs/blob/flakes/rfcs/0049-flakes.md) support. I'm opening as a draft since flakes are not yet merged and subject to change. Not everything works just yet, since `fetchurl` must provide a checksum in flakes. Could use some help exploring possible solutions. 

Since the manifest files get updated on a fairly frequent basis, I was thinking maybe a simple shell script that runs `nix-prefect-git` on their urls and stores the sums in a local json file, which then gets pulled in to the overlays. Since this might cause a lot of commits every time they change, maybe there is a simpler way. I've tried supplying their sha256 sums manually just to ensure everything works, and it does.