### PR TITLE
Fix rustdoc with non-default targets

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -279,13 +279,18 @@ let
             name = name + "-" + version;
             paths = components;
             postBuild = ''
-	      # If rustc is in the derivation, we need to copy the rustc
-	      # executable into the final derivation. This is required
-	      # for making rustc find the correct SYSROOT.
+              # If rustc or rustdoc is in the derivation, we need to copy their
+              # executable into the final derivation. This is required
+              # for making them find the correct SYSROOT.
               if [ -e "$out/bin/rustc" ]; then
                 RUSTC_PATH=$(realpath -e $out/bin/rustc)
                 rm $out/bin/rustc
                 cp $RUSTC_PATH $out/bin/rustc
+              fi
+              if [ -e "$out/bin/rustdoc" ]; then
+                RUSTDOC_PATH=$(realpath -e $out/bin/rustdoc)
+                rm $out/bin/rustdoc
+                cp $RUSTDOC_PATH $out/bin/rustdoc
               fi
             '';
 

--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -282,16 +282,11 @@ let
               # If rustc or rustdoc is in the derivation, we need to copy their
               # executable into the final derivation. This is required
               # for making them find the correct SYSROOT.
-              if [ -e "$out/bin/rustc" ]; then
-                RUSTC_PATH=$(realpath -e $out/bin/rustc)
-                rm $out/bin/rustc
-                cp $RUSTC_PATH $out/bin/rustc
-              fi
-              if [ -e "$out/bin/rustdoc" ]; then
-                RUSTDOC_PATH=$(realpath -e $out/bin/rustdoc)
-                rm $out/bin/rustdoc
-                cp $RUSTDOC_PATH $out/bin/rustdoc
-              fi
+              for target in $out/bin/{rustc,rustdoc}; do
+                if [ -e $target ]; then
+                  cp --remove-destination "$(realpath -e $target)" $target
+                fi
+              done
             '';
 
             # Add the compiler as part of the propagated build inputs in order


### PR DESCRIPTION
`rustdoc` did not detect `core` for other targets as it was handled differently from `rustc`. I tested locally that this fix works. Apparently this also fixes some whitespace.