### PR TITLE
cbindgen: 0.13.1 -> 0.14.2

### DIFF
--- a/pkgs/cbindgen/default.nix
+++ b/pkgs/cbindgen/default.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rust-cbindgen";
-  version = "0.13.1";
+  version = "0.14.2";
 
   src = fetchFromGitHub {
     owner = "eqrion";
     repo = "cbindgen";
     rev = "v${version}";
-    sha256 = "1x21g66gri6z9bnnfn7zmnf2lwdf5ing76pcmw0ilx4nzpvfhkg0";
+    sha256 = "15mk7q89rs723c7i9wwq4rrvakwh834wvrsmsnayji5k1kwaj351";
   };
 
-  cargoSha256 = "13fb8cdg6r0g5jb3vaznvv5aaywrnsl2yp00h4k8028vl8jwwr79";
+  cargoSha256 = "1avdpfsylf7cdsyk0sj8xyfamj07dqxivxxwshsfckrzhizdqm50";
 
   # buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
 


### PR DESCRIPTION
I fixed it because a newer version of cbindgen is needed to build Firefox.