### PR TITLE
firefox-overlay: expose more for flakes overlay/users

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -156,7 +156,7 @@ in
 {
   lib = super.lib // {
     firefoxOverlay = {
-      inherit firefoxVersion;
+      inherit firefoxVersion versionInfo firefox_versions;
     };
   };
 

--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -45,7 +45,8 @@ let
 
   # The timestamp argument is a yyyy-mm-dd-hh-mm-ss date, which corresponds to
   # one specific version. This is used mostly for bisecting.
-  versionInfo = { name, version, release, system ? arch, timestamp ? null }: with builtins;
+  versionInfo = { name, version, release, system ? arch, timestamp ? null, info ? null }: with builtins;
+    if (info != null) then info else
     if release then
       # For versions such as Beta & Release:
       # https://download.cdn.mozilla.net/pub/firefox/releases/55.0b3/SHA256SUMS


### PR DESCRIPTION
This is sort of an experiment for now until I get more feedback.

This is a small tweak that allows me to consume this overlay in [flake-firefox-nightly](https://github.com/colemickens/flake-firefox-nightly) and expose a `--pure-eval`-able `firefox-nightly` attribute for flakes users that want to pin everything and have a purely eval-able system.

Fundamentally this exposes functions so that an outside caller can determine latest information and checksums and then re-instantiate that exact version purely later. (See `update.sh` in **flake-firefox-nightly** for more of an idea of how it works.)