### PR TITLE
Support pre-20.03 Nixpkgs

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -80,7 +80,7 @@ let
       "armv6l" = "arm";
     }.${cpu.name} or platform.rustc.arch or cpu.name;
   in platform.rustc.config
-    or "${cpu_}-${vendor.name}-${kernel.name}${lib.optionalString (abi.name != "unknown") "-${abi.name}"}");
+    or "${cpu_}-${vendor.name}-${kernel.name}${super.lib.optionalString (abi.name != "unknown") "-${abi.name}"}");
 
   getTuples = pkgs: name: targets:
     builtins.map (target: { inherit name target; }) (builtins.filter (target: hasTarget pkgs name target) targets);


### PR DESCRIPTION
toRustTarget was added in https://github.com/nixos/nixpkgs/commits/83ac9c07e4df352e177ebdf978320089a137183a

So not all nixpkgs have it. We can provide a backup of it in this
case.

Fixes #232