### PR TITLE
Remove unused gstreamer dependency

### DIFF
--- a/pkgs/gecko/default.nix
+++ b/pkgs/gecko/default.nix
@@ -1,7 +1,7 @@
 { geckoSrc ? null, lib
 , stdenv, fetchFromGitHub, pythonFull, which, autoconf213
 , perl, unzip, zip, gnumake, yasm, pkgconfig, xlibs, gnome2, pango, freetype, fontconfig, cairo
-, dbus, dbus_glib, alsaLib, libpulseaudio, gstreamer, gst_plugins_base
+, dbus, dbus_glib, alsaLib, libpulseaudio
 , gtk3, glib, gobjectIntrospection, gdk_pixbuf, atk, gtk2
 , git, mercurial, openssl, cmake, procps
 , libnotify
@@ -65,7 +65,6 @@ let
     dbus dbus_glib
 
     alsaLib libpulseaudio
-    gstreamer gst_plugins_base
 
     gtk3 glib gobjectIntrospection gdk_pixbuf atk
     gtk2 gnome2.GConf


### PR DESCRIPTION
According to [this bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=1234092), Firefox removed gstreamer support a few years ago.