### PR TITLE
Use Python 3.6 instead of Python 3.5 for firefox-overlay

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -188,8 +188,8 @@ in
   # Set of packages which used to build developer environment
   devEnv = (super.shell or {}) // {
     gecko = super.callPackage ./pkgs/gecko {
-      inherit (self.python35Packages) setuptools;
-      pythonFull = self.python35Full;
+      inherit (self.python36Packages) setuptools;
+      pythonFull = self.python36Full;
       nodejs =
         if builtins.compareVersions self.nodejs.name "nodejs-8.11.3" < 0
         then self.nodejs-8_x else self.nodejs;


### PR DESCRIPTION
From `python ./mach build`:

```
 0:00.57 ERROR: One of the following Python versions are required:
 0:00.57 ERROR: * Python 2.7.3 or greater
 0:00.57 ERROR: * Python 3.6.0 or greater
 0:00.57 ERROR: You are running Python 3.5.9.
```