### PR TITLE
Add rust platform compatible with nixpkgs rust platform

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -310,6 +310,35 @@ rec {
     };
   };
 
+  # Params:
+  #   rustChannel:
+  #     A rust channel created using 
+  #     any of the functions below
+  # Returns 
+  #   A rustPlatform which is 
+  #   compatible with nixpkgs.rustPlatform
+  rustPlatformOf = rustChannel: 
+  let 
+    rustc    = rustChannel.rust;
+    cargo    = rustChannel.cargo;
+    rustcSrc = rustChannel.rust-src;
+
+  fetchCargoTarball = super.rustPlatform.fetchCargoTarball.override{
+    inherit cargo;
+  };
+
+  buildRustPackage = super.rustPlatform.buildRustPackage.override{
+    inherit rustc cargo fetchCargoTarball;
+  };
+  in
+  {
+    rust = {
+      inherit rustc cargo;
+    };
+
+    inherit fetchCargoTarball buildRustPackage rustcSrc;
+  };
+
   rustChannelOf = { sha256 ? null, ... } @ manifest_args: fromManifest
     sha256 (manifest_v2_url manifest_args)
     { inherit (self) stdenv fetchurl patchelf; }


### PR DESCRIPTION
This change adds a rust platform that can be directly used to compile rust applications from nixpkgs. e.g. rust-analyzer would be installed as 

```
	rust-analyzer = nixpkgs.rust-analyzer.override{ 
		unwrapped = (
			nixpkgs.rust-analyzer-unwrapped.override
			{
				rustPlatform = ( nixpkgs.rustPlatformOf ( nixpkgs.rustChannelOf rustVersion ) );
;
				cargoSha256 = "15kjcgxmigm0lwbp8p0kdxax86ldjqq9q8ysj6khfhqd0173184n";
			}
		);
	};
```

I tested this using the following `shell.nix`-

```
{
	nixpkgs_tarball ? 
		fetchTarball
		{
			url = https://github.com/NixOS/nixpkgs/archive/ef1fd9d0fb64f80aedcd77be6733d7a8c858dba8.tar.gz;
			sha256 = "14knhkvllzqqwls70j5kjxkm6ia3mxmjcwh2fwn3phvx6s910i2a";
		}
	, 
	rustVersion? { date = "2020-08-07"; channel = "nightly" ; },
}: 

# https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md
let 
	moz_overlay = import (
		/home/zx/workspace/git/nixpkgs-mozilla
	);

	nixpkgs  = ( 
		import 
			nixpkgs_tarball
			{
				overlays = [ moz_overlay ];
			} 
	);
	# extraBuildInputs = ( builtins.map ( ebis: nixpkgs.${ebis} ) extraBuildInputStrings );
	rustExtensions =
		[ 
			"rust-src" 
		]
	;

	mozilla_rust_platform = ( nixpkgs.rustPlatformOf ( nixpkgs.rustChannelOf rustVersion ) );

	rust-analyzer = nixpkgs.rust-analyzer.override{ 
		unwrapped = (
			nixpkgs.rust-analyzer-unwrapped.override
			{
				rustPlatform = mozilla_rust_platform;
				cargoSha256 = "15kjcgxmigm0lwbp8p0kdxax86ldjqq9q8ysj6khfhqd0173184n";
			}
		);
	};
in
		nixpkgs.stdenv.mkDerivation {
				name = "blah";
				buildInputs = [ rust-analyzer ];
		} 



```

I did two tests with two different versions of nightlies and in `nix show-derivation` of respective derivations, rust source's date was as expected. Let me know if you need me to make any changes. 
