### PR TITLE
rust-overlay: Allow running ancient pre-xz versions

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -97,7 +97,7 @@ let
       pkg = pkgs.${pkgname};
       srcInfo = pkg.target.${target};
     in
-      (super.fetchurl { url = srcInfo.xz_url; sha256 = srcInfo.xz_hash; });
+      (super.fetchurl { url = srcInfo.xz_url or srcInfo.url; sha256 = srcInfo.xz_hash or srcInfo.hash; });
 
   checkMissingExtensions = pkgs: pkgname: stdenv: extensions:
     let


### PR DESCRIPTION
Before:

```console
$ nix-shell -p '(rustChannelOf { date = "2017-02-02"; }).rustc' --run 'rustc --version'
error: attribute 'xz_url' missing, at /home/anders/nix/nixpkgs-mozilla/rust-overlay.nix:100:31
(use '--show-trace' to show detailed location information)
```

After:

```console
$ nix-shell -p '(rustChannelOf { date = "2017-02-02"; }).rustc' --run 'rustc --version'
rustc 1.16.0-nightly (24055d0f2 2017-01-31)
```