### PR TITLE
rust-overlay.nix: fix pretty-printers for rust-gdb

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -276,7 +276,9 @@ let
               # If rustc or rustdoc is in the derivation, we need to copy their
               # executable into the final derivation. This is required
               # for making them find the correct SYSROOT.
-              for target in $out/bin/{rustc,rustdoc}; do
+              # Similarly, we copy the python files for gdb pretty-printers since
+              # its auto-load-safe-path mechanism doesn't like symlinked files.
+              for target in $out/bin/{rustc,rustdoc} $out/lib/rustlib/etc/*.py; do
                 if [ -e $target ]; then
                   cp --remove-destination "$(realpath -e $target)" $target
                 fi


### PR DESCRIPTION
gdb's auto-load mechanism resolves symlinks before checking if each file is
allowed via auto-load-safe-path. we fix this by copying over those files into the
final derivation, similar to {rustc,rustdoc}.

The issue can be easily reproduced:
```
$ rust-gdb target/debug/program
(...)

Reading symbols from target/debug/program...
warning: File "/nix/store/i4bi7d6q68m8kjqqx2j9zfry451sllbq-rust/lib/rustlib/etc/gdb_load_rust_pretty_printers.py" auto-loading has been declined by your `auto-load safe-path' set to "$debugdir:$datadir/auto-load:/nix/store/vran8acwir59772hj4vscr7zribvp7l5-gcc-9.3.0-lib:/nix/store/q1vicr5q8xkaajjlxd7v4ri4axhisaan-rust-1.45.0-nightly-2020-05-31-5fd2f06e9/lib/rustlib/etc".
To enable execution of this file add
	add-auto-load-safe-path /nix/store/i4bi7d6q68m8kjqqx2j9zfry451sllbq-rust/lib/rustlib/etc/gdb_load_rust_pretty_printers.py
line to your configuration file "/home/valodim/.gdbinit".
(...)
```

rust-gdb adds the correct directory relative to the rust sysroot (via `rustc`) to allowed paths, which is `/nix/store/q1vic.../lib/rustlib/etc` in the example above. but the pretty-printer files in that directory symlink  to `/nix/store/i4bi7d6q.../lib/rustlib/etc/`, and gdb refuses to load from that path.