### PR TITLE
Fix `rr-overlay.nix` for modern nixpkgs

### DIFF
--- a/rr-overlay.nix
+++ b/rr-overlay.nix
@@ -3,10 +3,10 @@ self: super:
 {
   # Add i686-linux platform as a valid target.
   rr = super.rr.override {
-    stdenv = self.stdenv // {
-      mkDerivation = args: self.stdenv.mkDerivation (args // {
+    gcc9Stdenv = self.gcc9Stdenv // {
+      mkDerivation = args: self.gcc9Stdenv.mkDerivation (args // {
         meta = args.meta // {
-          platforms = self.stdenv.lib.platforms.linux;
+          platforms = self.lib.platforms.linux;
         };
       });
     };


### PR DESCRIPTION
Fixes the error:
```
error: while evaluating anonymous function at /nix/store/…/nixos/lib/customisation.nix:77:32,
  called from /nix/store/…/rr-overlay.nix:5:8:
while evaluating 'makeOverridable' at /nix/store/…/nixos/lib/customisation.nix:67:24,
  called from /nix/store/…/nixos/lib/customisation.nix:77:41:
anonymous function at /nix/store/…/nixos/pkgs/development/tools/analysis/rr/default.nix:1:1
  called with unexpected argument 'stdenv',
  at /nix/store/…/nixos/lib/customisation.nix:69:16
```
As of https://github.com/NixOS/nixpkgs/commit/b60b4023d72b468ec734fba83d902a9b9f6a3625, `rr` in nixpkgs now expects a `gcc9Stdenv` argument instead of a `stdenv` argument.