### PR TITLE
firefoxVersion: Fix for upstream browserName → applicationName rename

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -145,7 +145,12 @@ let
       # Add a dependency on the signature check.
       src = fetchVersion info;
     })) {
-      browserName = "firefox";
+      ${
+        if super.firefox-unwrapped ? applicationName then
+          "applicationName"
+        else
+          "browserName"
+      } = "firefox";
       pname = "firefox-bin";
       desktopName = "Firefox";
     };


### PR DESCRIPTION
Fixes this error on current nixos-unstable:

```console
$ nix build -Lf '<nixpkgs>' latest.firefox-bin
error: 'wrapper' at /nix/store/bgamkl5agk73pncifps984yil4hfhvkk-nixos-21.11pre308541.6fc5211eddd/nixos/pkgs/applications/networking/browsers/firefox/wrapper.nix:23:5 called with unexpected argument 'browserName', at /nix/store/bgamkl5agk73pncifps984yil4hfhvkk-nixos-21.11pre308541.6fc5211eddd/nixos/lib/customisation.nix:69:16
```

See NixOS/nixpkgs@711d674e1322a8ccdbf985322468da87a141bc9c.