### PR TITLE
Revert "firefox: Firefox nightly depends on libXtst."

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -134,11 +134,6 @@ let
         '';
       };
 
-  # Convert The version number from "96.0a1" to 96 integer.
-  getMajorVersion = version:
-    with builtins;
-    fromJSON (head (match "([0-9]+)[.].*" version.version));
-
   firefoxVersion = version:
     let info = versionInfo version; in
     super.wrapFirefox ((self.firefox-bin-unwrapped.override {
@@ -149,12 +144,6 @@ let
     }).overrideAttrs (old: {
       # Add a dependency on the signature check.
       src = fetchVersion info;
-
-      # Since Firefox 96.0a1, Firefox depends on libXtst, which is not yet
-      # reflected on Nixpkgs.
-      libPath = with super.lib;
-        old.libPath
-        + optionalString (96 >= getMajorVersion version) (":" + makeLibraryPath [self.xorg.libXtst]);
     })) {
       ${
         if super.firefox-unwrapped ? applicationName then


### PR DESCRIPTION
Reverts mozilla/nixpkgs-mozilla#268
This does not seems to be necessary anymore, and this method seems to have caused issues with Nixpkgs 21.05. (#270 )
