### PR TITLE
Revert "Revert "firefox: Firefox nightly depends on libXtst.""

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -134,6 +134,11 @@ let
         '';
       };
 
+  # Convert The version number from "96.0a1" to 96 integer.
+  getMajorVersion = version:
+    with builtins;
+    fromJSON (head (match "([0-9]+)[.].*" version.version));
+
   firefoxVersion = version:
     let info = versionInfo version; in
     super.wrapFirefox ((self.firefox-bin-unwrapped.override {
@@ -144,6 +149,12 @@ let
     }).overrideAttrs (old: {
       # Add a dependency on the signature check.
       src = fetchVersion info;
+
+      # Since Firefox 96.0a1, Firefox depends on libXtst, which is not yet
+      # reflected on Nixpkgs.
+      libPath = with super.lib;
+        old.libPath
+        + optionalString (96 >= getMajorVersion version) (":" + makeLibraryPath [self.xorg.libXtst]);
     })) {
       ${
         if super.firefox-unwrapped ? applicationName then


### PR DESCRIPTION
This reverts commit 728f3df8936c74ca5417259bb602e9bac66e3e60.
Apparently `libXtst` is still mandatory and we have to find another way to extend the libPath which is compatible with Nixpkgs 21.05.