### PR TITLE
Require Python38 instead of Python36

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,6 @@ Current packages
 
 - gecko (https://github.com/mozilla/gecko-dev)
 - firefox-bin variants including Nightly
-- VidyoDesktop ()
 
 firefox-bin variants
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,9 @@ toolchain or architecture.
   ~/mozilla-central$ nix-shell ../nixpkgs-mozilla/release.nix -A gecko.x86_64-linux.gcc --pure
     ... pull the rust compiler
     ... compile the toolchain
+  # First time only - initialize virtualenv
+  [~/mozilla-central] python ./mach create-mach-environment
+     ... create .mozbuild/_virtualenvs/mach
   [~/mozilla-central] python ./mach build
     ... build firefox desktop
   [~/mozilla-central] python ./mach run

--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -202,8 +202,8 @@ in
   # Set of packages which used to build developer environment
   devEnv = (super.shell or {}) // {
     gecko = super.callPackage ./pkgs/gecko {
-      inherit (self.python36Packages) setuptools;
-      pythonFull = self.python36Full;
+      inherit (self.python38Packages) setuptools;
+      pythonFull = self.python38Full;
       nodejs =
         if builtins.compareVersions self.nodejs.name "nodejs-8.11.3" < 0
         then self.nodejs-8_x else self.nodejs;

--- a/release.nix
+++ b/release.nix
@@ -97,7 +97,6 @@ let
     # Which will spawn a new shell where the closure of everything used to build
     # Gecko would be part of the fake-root.
     gecko = build [ "devEnv" "gecko" ] { compilers = geckoCompilers; };
-    VidyoDesktop = build [ "VidyoDesktop" ];
     latest = {
       "firefox-nightly-bin" = build [ "latest" "firefox-nightly-bin" ];
     };


### PR DESCRIPTION
Gecko needs `zstandard` package, which first appears in Python-3.8.
Also follows up to #273 a bit and adds an important note to the readme.