### PR TITLE
Add initial flake support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,33 @@ Example of using in ```shell.nix```:
      ];
    }
 
+Flake usage
+-----------
+This repository contains a minimal flake interface for the various
+overlays in this repository. To use it in your own flake, add it as
+an input to your ``flake.nix``:
+
+.. code:: nix
+ {
+   inputs.nixpkgs.url = github:NixOS/nixpkgs;
+   inputs.nixpkgs-mozilla.url = github:mozilla/nixpkgs-mozilla;
+
+   outputs = { self, nixpkgs, nixpkgs-mozilla }: {
+     devShell."x86_64-linux" = let
+       pkgs = import nixpkgs { system = "x86_64-linux"; overlays = [ nixpkgs-mozilla.overlay ]; };
+     in pkgs.mkShell {
+       buildInputs = [ pkgs.latest.rustChannels.nightly.rust ];
+     };
+   };
+  }
+The available overlays are ``nixpkgs-mozilla.overlay`` for the
+default overlay containing everything, and
+``nixpkgs-mozilla.{lib, rust, rr, firefox, git-cinnabar}-overlay``
+respectively. Depending on your use case, you might need to set the
+``--impure`` flag when invoking the ``nix`` command. This is because
+this repository fetches resources from non-pinned URLs
+non-reproducibly.
+
 Firefox Development Environment
 -------------------------------
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Mozilla overlay for Nixpkgs";
+
+  outputs = { self, ... }: {
+    # Default overlay.
+    overlay = import ./default.nix;
+
+    # Inidividual overlays.
+    overlays = {
+      lib = import ./lib-overlay.nix;
+      rust = import ./rust-overlay.nix;
+      rr = import ./rr-overlay;
+      firefox = import ./firefox-overlay.nix;
+      git-cinnabar = import ./git-cinnabar-overlay.nix;
+    };
+  };
+}


### PR DESCRIPTION
Resurrects #248. This PR adds flake support by exposing the available overlays as flake outputs. It deliberately does not include the packages themselves as outputs, because doing so would require pinning the flake to a certain revision of Nixpkgs via a `flake.lock` file.