### PR TITLE
Fix Importing `rr-overlay.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     overlays = {
       lib = import ./lib-overlay.nix;
       rust = import ./rust-overlay.nix;
-      rr = import ./rr-overlay;
+      rr = import ./rr-overlay.nix;
       firefox = import ./firefox-overlay.nix;
       git-cinnabar = import ./git-cinnabar-overlay.nix;
     };


### PR DESCRIPTION
The repository flake currently tries to import `rr-overlay`, without an extension, so here's a fix for that typo.