### PR TITLE
firefox-overlay: pass wmClass to wrapFirefox if supported

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -143,7 +143,7 @@ let
     let
       wrapper = super.wrapFirefox pkg {};
 
-      wrapperArgs = wrapper.override.__functionArgs;
+      wrapperArgs = super.lib.functionArgs wrapper.override;
       wrapperHasArg = arg: builtins.hasAttr arg wrapperArgs;
 
       nameArg = if wrapperHasArg "applicationName"


### PR DESCRIPTION
Fixes window to desktop entry mapping on Plasma, and probably just about every other X11 desktop. There's some crimes to get to the actual wrapped `wrapFirefox`'s signature, but other than that it seems not terrible.