### PR TITLE
 firefox-overlay: remove unnecessary information 

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -155,16 +155,7 @@ let
       libPath = with super.lib;
         old.libPath
         + optionalString (96 >= getMajorVersion version) (":" + makeLibraryPath [self.xorg.libXtst]);
-    })) {
-      ${
-        if super.firefox-unwrapped ? applicationName then
-          "applicationName"
-        else
-          "browserName"
-      } = "firefox";
-      pname = "firefox-bin";
-      desktopName = "Firefox";
-    };
+    })) { };
 in
 
 {


### PR DESCRIPTION
we are overriding firefox-bin so we don't need to specify these