### PR TITLE
applicationName is now binaryName in upstream firefox

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -157,7 +157,9 @@ let
         + optionalString (96 >= getMajorVersion version) (":" + makeLibraryPath [self.xorg.libXtst]);
     })) {
       ${
-        if super.firefox-unwrapped ? applicationName then
+        if super.firefox-unwrapped ? binaryName then
+          "binaryName"
+        else if super.firefox-unwrapped ? applicationName then
           "applicationName"
         else
           "browserName"

--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -158,7 +158,7 @@ let
     })) {
       ${
         if super.firefox-unwrapped ? binaryName then
-          "binaryName"
+          "applicationName"
         else if super.firefox-unwrapped ? applicationName then
           "applicationName"
         else


### PR DESCRIPTION
I have been using this patch for a couple of days to get firefox nightly working in NixOS with the nixpkgs-unstable channel.

The error is the same as in #262, but I think it is related to https://github.com/NixOS/nixpkgs/pull/165161/files.

This is the snippet of /etc/nixos/configuration.nix that I am using:
```nix
{ config, pkgs, ... }:
{ # ...
  nixpkgs.config.allowUnfree = true;
  nixpkgs.overlays =
    let
      moz-rev = "master";
      moz-url = builtins.fetchTarball { url = "https://github.com/marcenuc/nixpkgs-mozilla/archive/${moz-rev}.tar.gz";};
      nightlyOverlay = (import "${moz-url}/firefox-overlay.nix");
    in [
      nightlyOverlay
    ];
  environment.systemPackages = with pkgs; [
    latest.firefox-nightly-bin
    # ...
  ];
  # ...
}
```