### PR TITLE
Replace removed runCommandNoCC alias with runCommand

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -87,7 +87,7 @@ let
   # From the version info, check the authenticity of the check sum file, such
   # that we guarantee that we have
   verifyFileAuthenticity = { file, asc }:
-    if asc == null then "" else super.runCommandNoCC "check-firefox-signature" {
+    if asc == null then "" else super.runCommand "check-firefox-signature" {
       buildInputs = [ self.gnupg ];
       FILE = file;
       ASC = asc;


### PR DESCRIPTION
It has been synonymous with runCommand since https://github.com/NixOS/nixpkgs/commit/97bfc2fac92d90c668ae1ec078356d0bd0a9ddb7 (2016-09-26), was deprecated in https://github.com/NixOS/nixpkgs/pull/134225 (2021-08-15), and was removed in https://github.com/NixOS/nixpkgs/pull/192681 (2022-09-24).

Fixes an evaluation failure on current `nixos-unstable`.

Cc @nbp