### PR TITLE
Fix SYSROOT detection on latest nightly

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -288,7 +288,20 @@ let
                 if [ -e $target ]; then
                   cp --remove-destination "$(realpath -e $target)" $target
                 fi
+
+                # The SYSROOT is determined by using the librustc_driver-*.so.
+                # So, we need to point to the *.so files in our derivation.
+                chmod u+w $target
+                patchelf --set-rpath "$out/lib" $target || true
               done
+
+              # Here we copy the librustc_driver-*.so to our derivation.
+              # The SYSROOT is determined based on the path of this library.
+              if ls $out/lib/librustc_driver-*.so &> /dev/null; then
+                RUSTC_DRIVER_PATH=$(realpath -e $out/lib/librustc_driver-*.so)
+                rm $out/lib/librustc_driver-*.so
+                cp $RUSTC_DRIVER_PATH $out/lib/
+              fi
             '';
 
             # Export the manifest file as part of the nix-support files such


### PR DESCRIPTION
Rust changed the way the SYSROOT is determined in: https://github.com/rust-lang/rust/pull/103660

Before this change the SYSROOT was determined based on the rustc executable. Now it is determined based on the librustc_driver-*.so file. This pr fixes the detection by copying the library to the derivation as we have done it for the rustc executable.