### PR TITLE
rust-overlay: restore SYSROOT detection for Darwin

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -297,12 +297,8 @@ let
 
               # Here we copy the librustc_driver-*.{so,dylib} to our derivation.
               # The SYSROOT is determined based on the path of this library.
-              if test "" != $out/lib/librustc_driver-*.so &> /dev/null; then
-                RUSTC_DRIVER_PATH=$(realpath -e $out/lib/librustc_driver-*.so)
-                cp --remove-destination $RUSTC_DRIVER_PATH $out/lib/
-              fi
-              if test "" != $out/lib/librustc_driver-*.dylib &> /dev/null; then
-                RUSTC_DRIVER_PATH=$(realpath -e $out/lib/librustc_driver-*.dylib)
+              if test "" != $out/lib/librustc_driver-*${stdenv.hostPlatform.extensions.sharedLibrary} &> /dev/null; then
+                RUSTC_DRIVER_PATH=$(realpath -e $out/lib/librustc_driver-*${stdenv.hostPlatform.extensions.sharedLibrary})
                 cp --remove-destination $RUSTC_DRIVER_PATH $out/lib/
               fi
             '';

--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -289,19 +289,20 @@ let
                   cp --remove-destination "$(realpath -e $target)" $target
                 fi
 
-                # The SYSROOT is determined by using the librustc_driver-*.so.
+                # The SYSROOT is determined by using the librustc_driver-*.{so,dylib}.
                 # So, we need to point to the *.so files in our derivation.
-                chmod u+w $target
-                patchelf --set-rpath "$out/lib" $target || true
+                shopt -u nullglob
+                if ls $out/lib/*.so &>/dev/null; then
+                  chmod u+w $target
+                  patchelf --set-rpath "$out/lib" $target || true
+                fi
               done
 
-              # Here we copy the librustc_driver-*.so to our derivation.
+              # Here we copy the librustc_driver-*.{so,dylib} to our derivation.
               # The SYSROOT is determined based on the path of this library.
-              if ls $out/lib/librustc_driver-*.so &> /dev/null; then
-                RUSTC_DRIVER_PATH=$(realpath -e $out/lib/librustc_driver-*.so)
-                rm $out/lib/librustc_driver-*.so
-                cp $RUSTC_DRIVER_PATH $out/lib/
-              fi
+              shopt -s nullglob
+              RUSTC_DRIVER_PATH=$(realpath -e $out/lib/librustc_driver-*.{so,dylib})
+              cp --remove-destination $RUSTC_DRIVER_PATH $out/lib/
             '';
 
             # Export the manifest file as part of the nix-support files such


### PR DESCRIPTION
f6fe8508b0910b84b74c0e0bfa0ff8593e77d470 broke Darwin (fixes #304).
This PR:
- removes `rm` before `cp` (and uses `--remove-destination` instead)
- copies `librustc_driver-*.dylib` too

Takes some cues from #306 (and supersedes it).