### PR TITLE
fix package aliases that were removed in NixOS 22.05

### DIFF
--- a/pkgs/gcc-4.7/default.nix
+++ b/pkgs/gcc-4.7/default.nix
@@ -90,7 +90,7 @@ let version = "4.7.3";
       sha256 = "1f41j0y4kjydl71lqlvr73yagrs2jsg1fjymzjz66mjy7al5lh09";
     };
 
-    xlibs = [
+    xorg = [
       libX11 libXt libSM libICE libXtst libXrender libXrandr libXi
       xproto renderproto xextproto inputproto randrproto
     ];
@@ -199,7 +199,7 @@ let version = "4.7.3";
 in
 
 # We need all these X libraries when building AWT with GTK+.
-assert gtk != null -> (filter (x: x == null) xlibs) == [];
+assert gtk != null -> (filter (x: x == null) xorg) == [];
 
 stdenv.mkDerivation ({
   name = "${name}${if stripped then "" else "-debug"}-${version}" + crossNameAddon;
@@ -279,7 +279,7 @@ stdenv.mkDerivation ({
     ++ (optional (cloog != null) cloog)
     ++ (optional (zlib != null) zlib)
     ++ (optionals langJava [ boehmgc zip unzip ])
-    ++ (optionals javaAwtGtk ([ gtk libart_lgpl ] ++ xlibs))
+    ++ (optionals javaAwtGtk ([ gtk libart_lgpl ] ++ xorg))
     ++ (optionals (cross != null) [binutilsCross])
     ++ (optionals langAda [gnatboot])
     ++ (optionals langVhdl [gnat])
@@ -458,7 +458,7 @@ stdenv.mkDerivation ({
             (intersperse ":" (map (x: x + "/include")
                                   (optionals (zlib != null) [ zlib ]
                                    ++ optionals langJava [ boehmgc ]
-                                   ++ optionals javaAwtGtk xlibs
+                                   ++ optionals javaAwtGtk xorg
                                    ++ optionals javaAwtGtk [ gmp mpfr ]
                                    ++ optional (libpthread != null) libpthread
                                    ++ optional (libpthreadCross != null) libpthreadCross
@@ -473,7 +473,7 @@ stdenv.mkDerivation ({
                    (intersperse ":" (map (x: x + "/lib")
                                          (optionals (zlib != null) [ zlib ]
                                           ++ optionals langJava [ boehmgc ]
-                                          ++ optionals javaAwtGtk xlibs
+                                          ++ optionals javaAwtGtk xorg
                                           ++ optionals javaAwtGtk [ gmp mpfr ]
                                           ++ optional (libpthread != null) libpthread)));
 

--- a/pkgs/gecko/default.nix
+++ b/pkgs/gecko/default.nix
@@ -1,8 +1,8 @@
 { geckoSrc ? null, lib
 , stdenv, fetchFromGitHub, pythonFull, which, autoconf213, m4
-, perl, unzip, zip, gnumake, yasm, pkgconfig, xlibs, gnome2, pango, freetype, fontconfig, cairo
-, dbus, dbus_glib, alsaLib, libpulseaudio
-, gtk3, glib, gobjectIntrospection, gdk_pixbuf, atk, gtk2
+, perl, unzip, zip, gnumake, yasm, pkgconfig, xorg, gnome2, pango, freetype, fontconfig, cairo
+, dbus, dbus-glib, alsaLib, libpulseaudio
+, gtk3, glib, gobject-introspection, gdk-pixbuf, atk, gtk2
 , git, mercurial, openssl, cmake, procps
 , libnotify
 , valgrind, gdb, rr
@@ -13,7 +13,7 @@
 , llvm, llvmPackages, nasm
 , ccache
 
-, zlib, xorg
+, zlib
 , rust-cbindgen
 , nodejs
 , jsdoc
@@ -46,15 +46,15 @@ let
     # Expected by the configure script
     perl unzip zip gnumake yasm pkgconfig
 
-    xlibs.libICE xlibs.libSM xlibs.libX11 xlibs.libXau xlibs.libxcb
-    xlibs.libXdmcp xlibs.libXext xlibs.libXt xlibs.libXtst
-    xlibs.libXcomposite
-    xlibs.libXfixes
-    xlibs.libXdamage xlibs.libXrender
-    ] ++ (if xlibs ? xproto then [
-    xlibs.damageproto xlibs.printproto xlibs.kbproto
-    xlibs.renderproto xlibs.xextproto xlibs.xproto
-    xlibs.compositeproto xlibs.fixesproto
+    xorg.libICE xorg.libSM xorg.libX11 xorg.libXau xorg.libxcb
+    xorg.libXdmcp xorg.libXext xorg.libXt xorg.libXtst
+    xorg.libXcomposite
+    xorg.libXfixes
+    xorg.libXdamage xorg.libXrender
+    ] ++ (if xorg ? xproto then [
+    xorg.damageproto xorg.printproto xorg.kbproto
+    xorg.renderproto xorg.xextproto xorg.xproto
+    xorg.compositeproto xorg.fixesproto
     ] else [
     xorg.xorgproto
     ]) ++ [
@@ -64,11 +64,11 @@ let
 
     pango freetype fontconfig cairo
 
-    dbus dbus_glib
+    dbus dbus-glib
 
     alsaLib libpulseaudio
 
-    gtk3 glib gobjectIntrospection gdk_pixbuf atk
+    gtk3 glib gobject-introspection gdk-pixbuf atk
     gtk2 gnome2.GConf
 
     rust


### PR DESCRIPTION
NixOS/nixpkgs#161146 breaks these old aliases:

* xlibs → xorg
* dbus_glib → dbus-glib
* gobjectIntrospection → gobject-introspection
* gdk_pixbuf → gdk-pixbuf