### PR TITLE
Update gpg incantations to work with 2.4.1

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -96,10 +96,9 @@ let
       FILE = chksum;
       ASC = chksumSig;
     } ''
-      HOME=`mktemp -d`
       set -eu
-      gpg --import < ${pgpKey}
-      gpgv --keyring=$HOME/.gnupg/pubring.kbx $ASC $FILE
+      gpg --dearmor < ${pgpKey} > keyring.gpg
+      gpgv --keyring=./keyring.gpg $ASC $FILE
       mkdir $out
     '';
 
@@ -131,11 +130,10 @@ let
         postFetch =
           let asc = super.fetchurl { url = info.sig; sha512 = info.sigSha512; }; in ''
           : # Authenticity Check
-          HOME=`mktemp -d`
           set -eu
           export PATH="$PATH:${self.gnupg}/bin/"
-          gpg --import < ${pgpKey}
-          gpgv --keyring=$HOME/.gnupg/pubring.kbx ${asc} $out
+          gpg --dearmor < ${pgpKey} > keyring.gpg
+          gpgv --keyring=./keyring.gpg ${asc} $out
         '';
       };
 


### PR DESCRIPTION
There's some weird new behavior with keyring paths and keyboxd, so avoid the entire footgun by just explicitly telling it what key to use.