### PR TITLE
firefox-overlay: update KEY

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -4,8 +4,8 @@ self: super:
 let
   # This URL needs to be updated about every 2 years when the subkey is rotated.
   pgpKey = super.fetchurl {
-    url = "https://download.cdn.mozilla.net/pub/firefox/candidates/89.0-candidates/build2/KEY";
-    sha256 = "1zm3cq854v4aabzzginmjxdm4gidcf5b522h58272fb0x4z3nimw";
+    url = "https://download.cdn.mozilla.net/pub/firefox/candidates/114.0b3-candidates/build1/KEY";
+    hash = "sha256-vq9k1Q00cXWvMwjnOq7rVH+RLkU7sVWUEiy2acxMq/s=";
   };
 
   # This file is currently maintained manually, if this Nix expression attempt


### PR DESCRIPTION
react to this: https://blog.mozilla.org/security/2023/05/11/updated-gpg-key-for-signing-firefox-releases/

and flake-firefox-nightly has been failing to update because new builds are signed with the new key.

note: I haven't tested this yet to see how it affects stable/release builds. I don't know if they're already signed with the new key as well.