### PR TITLE
Update the GPG key which is used to sign Firefox releases.

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -4,8 +4,8 @@ self: super:
 let
   # This URL needs to be updated about every 2 years when the subkey is rotated.
   pgpKey = super.fetchurl {
-    url = "https://download.cdn.mozilla.net/pub/firefox/candidates/89.0-candidates/build2/KEY";
-    sha256 = "1zm3cq854v4aabzzginmjxdm4gidcf5b522h58272fb0x4z3nimw";
+    url = "https://download.cdn.mozilla.net/pub/firefox/candidates/113.0.1-candidates/build1/KEY";
+    sha256 = "beaf64d50d347175af3308e73aaeeb547f912e453bb15594122cb669cc4cabfb";
   };
 
   # This file is currently maintained manually, if this Nix expression attempt


### PR DESCRIPTION
The GPG key matches the one published on
https://blog.mozilla.org/security/2023/05/11/updated-gpg-key-for-signing-firefox-releases/
