### PR TITLE
doc: fix flake overlay path description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ an input to your ``flake.nix``:
   }
 The available overlays are ``nixpkgs-mozilla.overlay`` for the
 default overlay containing everything, and
-``nixpkgs-mozilla.{lib, rust, rr, firefox, git-cinnabar}-overlay``
+``nixpkgs-mozilla.overlay.{lib, rust, rr, firefox, git-cinnabar}``
 respectively. Depending on your use case, you might need to set the
 ``--impure`` flag when invoking the ``nix`` command. This is because
 this repository fetches resources from non-pinned URLs

--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ an input to your ``flake.nix``:
   }
 The available overlays are ``nixpkgs-mozilla.overlay`` for the
 default overlay containing everything, and
-``nixpkgs-mozilla.overlay.{lib, rust, rr, firefox, git-cinnabar}``
+``nixpkgs-mozilla.overlays.{lib, rust, rr, firefox, git-cinnabar}``
 respectively. Depending on your use case, you might need to set the
 ``--impure`` flag when invoking the ``nix`` command. This is because
 this repository fetches resources from non-pinned URLs


### PR DESCRIPTION
It looks like the README is somewhat out of date - `nix flake show` gives the correct information, but it's probably best to keep this up to date - Thanks!