### PR TITLE
Fix #304 build rust-src from overlay

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -287,12 +287,12 @@ let
               for target in $out/bin/{rustc,rustdoc} $out/lib/rustlib/etc/*.py; do
                 if [ -e $target ]; then
                   cp --remove-destination "$(realpath -e $target)" $target
-                fi
 
-                # The SYSROOT is determined by using the librustc_driver-*.so.
-                # So, we need to point to the *.so files in our derivation.
-                chmod u+w $target
-                patchelf --set-rpath "$out/lib" $target || true
+                  # The SYSROOT is determined by using the librustc_driver-*.so.
+                  # So, we need to point to the *.so files in our derivation.
+                  chmod u+w $target
+                  patchelf --set-rpath "$out/lib" $target || true
+                fi
               done
 
               # Here we copy the librustc_driver-*.so to our derivation.

--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -297,7 +297,7 @@ let
 
               # Here we copy the librustc_driver-*.so to our derivation.
               # The SYSROOT is determined based on the path of this library.
-              if ls $out/lib/librustc_driver-*.so &> /dev/null; then
+              if test "" != $out/lib/librustc_driver-*.so &> /dev/null; then
                 RUSTC_DRIVER_PATH=$(realpath -e $out/lib/librustc_driver-*.so)
                 rm $out/lib/librustc_driver-*.so
                 cp $RUSTC_DRIVER_PATH $out/lib/


### PR DESCRIPTION
When building rust-src like in
```
nix build --impure -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/tags/23.05.tar.gz --argstr PWD $PWD --expr \
'{ PWD }:(import <nixpkgs> { overlays = (builtins.getFlake PWD).overlays.rust ];}).latest.rustChannels.stable.rust-src' \
-L --out-link rust-src-stable
```
the build failed since commit https://github.com/mozilla/nixpkgs-mozilla/commit/f6fe8508b0910b84b74c0e0bfa0ff8593e77d470 with an error like
```
chmod: cannot access '/nix/store/rawpkwl6b5h2qqv41w8yqgpayp89q9xa-rust-src-1.71.0-2023-07-12-8ede3aae2/bin/rustc': No such file or directory
```
because, indeed this file is not present in rust-src build output.

This commit moves the failing commands inside the conditional block so that they are only executed when the file is present.
\
\
After fixing the previous error the build failed with an error like
```
realpath: missing operand
```
because, bash shopt nullglob is enabled during build which leads to a non-existing glob matching pattern to be a null string and therefore the check with `ls $out/lib/librustc_driver-*.so` lists the whole directory and succeeds.
```
bash -c 'shopt -s nullglob; if ls $PWD/rust-o*.nixxxxxxxxxxx &> /dev/null ; then echo yes ; else echo no ; fi'
yes
```

This commit changes the check to compare the null string resulting from glob pattern match with nullglob enabled against another null string.