### PR TITLE
Update extension of nightly builds to xz

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -49,6 +49,7 @@ let
       # https://download.cdn.mozilla.net/pub/firefox/releases/55.0b3/SHA256SUMS
       let
         dir = "https://download.cdn.mozilla.net/pub/firefox/releases/${version}";
+        # TODO: Update the extension once XZ linux builds leave nightly channel
         file = "${system}/en-US/firefox-${version}.tar.bz2";
         sha512Of = chksum: file: extractSha512Sum (readFile (fetchurl chksum)) file;
       in rec {
@@ -73,7 +74,7 @@ let
                 fromJSON (readFile (fetchurl "https://download.cdn.mozilla.net/pub/firefox/nightly/latest-mozilla-central/firefox-${version}.en-US.${system}.buildhub.json"));
             in builtins.replaceStrings [ "/${file}" ] [ "" ] buildhubJSON.download.url
           else "https://download.cdn.mozilla.net/pub/firefox/nightly/${yearOf timestamp}/${monthOf timestamp}/${timestamp}-mozilla-central" ;
-        file = "firefox-${version}.en-US.${system}.tar.bz2";
+        file = "firefox-${version}.en-US.${system}.tar.xz";
         sha512Of = chksum: file: head (match ".*[\n]([0-9a-f]*) sha512 [0-9]* ${file}[\n].*" (readFile (fetchurl chksum)));
       in rec {
         chksum = "${dir}/firefox-${version}.en-US.${system}.checksums";

--- a/pkgs/firefox-nightly-bin/update.nix
+++ b/pkgs/firefox-nightly-bin/update.nix
@@ -31,10 +31,10 @@ in writeScript "update-firefox-nightly-bin" ''
   {
     version = `echo $nightly_json | jq ."moz_app_version"` + "-" + `echo $nightly_json | jq ."buildid"`;
     sources = [
-      { url = "$url$nightly_file.tar.bz2";
+      { url = "$url$nightly_file.tar.xz";
         locale = "`echo $nightly_file | cut -d"." -f3`";
         arch = "`echo $nightly_file | cut -d"." -f4`";
-        sha512 = "`curl --silent $url$nightly_file.checksums | grep $nightly_file.tar.bz2$ | grep sha512 | cut -d" " -f1`";
+        sha512 = "`curl --silent $url$nightly_file.checksums | grep $nightly_file.tar.xz$ | grep sha512 | cut -d" " -f1`";
       }
     ];
   }


### PR DESCRIPTION
Bug [1710599](https://bugzilla.mozilla.org/show_bug.cgi?id=1710599) has changed linux builds from bz2 to xz. 
The change will ride the train and will eventually hit beta and release, at which point all the file references should also point to .xz (left a comment to reflect this).

Closes #334 