### PR TITLE
Fix evaluation error as of NixOS/nixpkgs#377863

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -145,21 +145,24 @@ let
   firefoxVersion = version:
     let
       info = versionInfo version;
-      pkg = ((self.firefox-bin-unwrapped.override {
+      pkg = ((self.firefox-bin-unwrapped.override ({
         generated = {
           version = version.version;
           sources = { inherit (info) url sha512; };
         };
         channel = version.channel;
-      }).overrideAttrs (old: {
+      } // super.lib.optionalAttrs (self.firefox-bin-unwrapped.passthru ? applicationName) {
+        applicationName = version.name;
+      })).overrideAttrs (old: {
         # Add a dependency on the signature check.
         src = fetchVersion info;
       }));
-      in super.wrapFirefox pkg {
+      in super.wrapFirefox pkg ({
         pname = "${pkg.binaryName}-bin";
-        desktopName = version.name;
         wmClass = version.wmClass;
-      };
+      } // super.lib.optionalAttrs (!self.firefox-bin-unwrapped.passthru ? applicationName) {
+        desktopName = version.name;
+      });
 
   firefoxVariants = {
     firefox-nightly-bin = {


### PR DESCRIPTION
    error: function 'wrapper' called with unexpected argument 'desktopName'
    at …/nixpkgs/pkgs/applications/networking/browsers/firefox/wrapper.nix:27:5:
        26|   wrapper =
        27|     { applicationName ? browser.binaryName or (lib.getName browser) # Note: this is actually *binary* name and is different from browser.passthru.applicationName, which is *app* name!
          |     ^
        28|     , pname ? applicationName

See https://github.com/NixOS/nixpkgs/commit/b856437376fd346ed9054a671ec602eff16f496f.