### PR TITLE
Update the GPG key which is used to sign Firefox releases.

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -4,8 +4,8 @@ self: super:
 let
   # This URL needs to be updated about every 2 years when the subkey is rotated.
   pgpKey = super.fetchurl {
-    url = "https://download.cdn.mozilla.net/pub/firefox/candidates/113.0.1-candidates/build1/KEY";
-    sha256 = "beaf64d50d347175af3308e73aaeeb547f912e453bb15594122cb669cc4cabfb";
+    url = "https://download.cdn.mozilla.net/pub/firefox/candidates/138.0b1-candidates/build1/KEY";
+    hash = "sha256-FOGtyDxtZpW6AbNdSj0QoK1AYkQYxHPypT8zJr2XYQk=";
   };
 
   # This file is currently maintained manually, if this Nix expression attempt


### PR DESCRIPTION
The GPG key published on the blog post contains only the non-expired subkeys, while the one downloaded from the CDN contains also expired subkeys.

The fingerprint of both the GPG key and the subkeys are confirmed to be identical:

```
$ diff --color -U50 \
    <(gpg --with-fingerprint --with-subkey-fingerprint --show-keys ./blog-KEY) \
    <(gpg --with-fingerprint --with-subkey-fingerprint --show-keys ./138.0b1-KEY)
--- /proc/self/fd/11	2025-04-01 12:32:55.182235913 +0200
+++ /proc/self/fd/12	2025-04-01 12:32:55.183235925 +0200
@@ -1,8 +1,16 @@
 pub   rsa4096 2015-07-17 [SC]
       14F2 6682 D091 6CDD 81E3  7B6D 61B7 B526 D98F 0353
 uid                      Mozilla Software Releases <release@mozilla.com>
+sub   rsa4096 2021-05-17 [S] [expired: 2023-05-17]
+      4360 FE21 09C4 9763 186F  8E21 EBE4 1E90 F6F1 2F6D
+sub   rsa4096 2015-07-17 [S] [expired: 2017-07-16]
+      F2EF 4E6E 6AE7 5B95 F11F  1EB5 1C69 C4E5 5E99 05DB
+sub   rsa4096 2017-06-22 [S] [expired: 2019-06-22]
+      DCEA C5D9 6135 B91C 4EA6  72AB BBBE BDBB 24C6 F355
+sub   rsa4096 2019-05-30 [S] [expired: 2021-05-29]
+      097B 3130 77AE 62A0 2F84  DA4D F1A6 668F BB7D 572E
 sub   rsa4096 2023-05-05 [S] [expires: 2025-05-04]
       ADD7 0794 7970 0DCA DFDD  5337 E36D 3B13 F3D9 3274
 sub   rsa4096 2025-03-13 [S] [expires: 2027-03-13]
       09BE ED63 F346 2A2D FFAB  3B87 5ECB 6497 C1A2 0256
```

Doing the same with the key server show the same keys and subkeys but in a different order.