### PR TITLE
Fix channel detection for rust-toolchain.toml

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -15,7 +15,17 @@ let
     # Parse *.toml files as TOML
     else if self.lib.strings.hasSuffix ".toml" file then
       ({ channel ? null, date ? null, ... }: { inherit channel date; })
-        (fromTOML (readFile file)).toolchain
+      (let
+        channel_regex = "(stable|beta|nightly).*";
+        date_regex = ".*([0-9]{4}-[0-9]{2}-[0-9]{2})";
+        toolchain = (fromTOML (readFile file)).toolchain;
+        channel_str = toolchain.channel;
+        channel = head (match channel_regex channel_str);
+        date = head (match date_regex channel_str);
+      in {
+        inherit channel;
+        inherit date;
+      })
     else
     # Otherwise, assume the file contains just a rust version string
       let


### PR DESCRIPTION
## Tl;dr
The current implementation assumes the presence of a key `date` which is not part of the `toolchain.toml` format. Instead, we need to parse the `channel`'s value to extract the `date` and `channel` from it to form a valid download URL.

## Problem
The overlay allows to specifiy a the path to `rust-toolchain.toml` to download the correct Rust toolchain. For this, the overlay uses the Nix builtin [fromTOML](https://nix.dev/manual/nix/2.18/language/builtins#builtins-fromTOML) to read the respective file. This function makes the `keys=value` of the `toolchain` section available. The current code assumes the presence of a key named `date` in the `toolchain` section. [Rust toolchain files](https://rust-lang.github.io/rustup/overrides.html#toolchain-file-settings) do not contain a key named `date`. Instead the date is part of the `channel` settings. As a result, the code evaluates to `NULL` for the variable `date` in the Nix code. For example, a `toolchain.toml` looking like this:

```
[toolchain]
channel = "nightly-2024-01-24"
components = [ "rust-std", "rust-src", "rustc", "cargo", "clippy", "rustfmt" ]
``` 

Leads to the generation of a invalid toolchain download URL, similar to:
```
trying https://static.rust-lang.org/dist/channel-rust-nightly-2024-01-24.toml
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0   312    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
error: cannot download channel-rust-nightly-2024-01-24.toml from any mirror
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'rust-workspace-unknown'
         whose name attribute is located at /nix/store/pp307nbzkgsd6393zl2i9j4j86z5nz9b-nixpkgs-src/pkgs/stdenv/generic/make-derivation.nix:302:7

       … while evaluating attribute 'RUSTC' of derivation 'rust-workspace-unknown'
         at /nix/store/nn3wrsxl9x4pjp4ivh3bka93jrm021kn-naersk-src/build.nix:144:5:
          143|
          144|     RUSTC = "${rustc}/bin/rustc";
             |     ^
          145|     cargo_release = lib.optionalString release "--release";

       … from call site
         at /home/xxxx/yyyy/cccc/nix/test.nix:13:16:
           12|
           13|   toolchain = (pkgs.rustChannelOf {
             |                ^
           14|     rustToolchain = ../implementation/rust-toolchain.toml;

       … while calling 'rustChannelOf'
         at /nix/store/b1gwcwpnssjyz76q7z090wya6b007v6k-nixpkgs-mozilla-src/rust-overlay.nix:351:19:
          350|
          351|   rustChannelOf = { sha256 ? null, ... } @ manifest_args: fromManifest
             |                   ^
          352|     sha256 (manifest_v2_url manifest_args)

       … from call site
         at /nix/store/b1gwcwpnssjyz76q7z090wya6b007v6k-nixpkgs-mozilla-src/rust-overlay.nix:351:59:
          350|
          351|   rustChannelOf = { sha256 ? null, ... } @ manifest_args: fromManifest
             |                                                           ^
          352|     sha256 (manifest_v2_url manifest_args)

       … while calling 'fromManifest'
         at /nix/store/b1gwcwpnssjyz76q7z090wya6b007v6k-nixpkgs-mozilla-src/rust-overlay.nix:337:36:
          336|
          337|   fromManifest = sha256: manifest: { stdenv, lib, fetchurl, patchelf }:
             |                                    ^
          338|     let manifestFile = if sha256 == null then builtins.fetchurl manifest else fetchurl { url = manifest; inherit sha256; };

       … from call site
         at /nix/store/b1gwcwpnssjyz76q7z090wya6b007v6k-nixpkgs-mozilla-src/rust-overlay.nix:339:8:
          338|     let manifestFile = if sha256 == null then builtins.fetchurl manifest else fetchurl { url = manifest; inherit sha256; };
          339|     in fromManifestFile manifestFile { inherit stdenv lib fetchurl patchelf; };
             |        ^
          340|

       … while calling 'fromManifestFile'
         at /nix/store/b1gwcwpnssjyz76q7z090wya6b007v6k-nixpkgs-mozilla-src/rust-overlay.nix:270:32:
          269|   #                       you will need to specify this extension in the extensions options or it will not be installed!
          270|   fromManifestFile = manifest: { stdenv, lib, fetchurl, patchelf }:
             |                                ^
          271|     let

       … from call site
         at /nix/store/b1gwcwpnssjyz76q7z090wya6b007v6k-nixpkgs-mozilla-src/rust-overlay.nix:277:5:
          276|     in
          277|     flip mapAttrs pkgs.pkg (name: pkg:
             |     ^
          278|       makeOverridable ({extensions, targets, targetExtensions}:

       … while calling 'flip'
         at /nix/store/pp307nbzkgsd6393zl2i9j4j86z5nz9b-nixpkgs-src/lib/trivial.nix:138:16:
          137|   */
          138|   flip = f: a: b: f b a;
             |                ^
          139|

       … while calling the 'mapAttrs' builtin
         at /nix/store/pp307nbzkgsd6393zl2i9j4j86z5nz9b-nixpkgs-src/lib/trivial.nix:138:19:
          137|   */
          138|   flip = f: a: b: f b a;
             |                   ^
          139|

       … while calling the 'fromTOML' builtin
         at /nix/store/b1gwcwpnssjyz76q7z090wya6b007v6k-nixpkgs-mozilla-src/rust-overlay.nix:275:14:
          274|       inherit (super.lib) flip mapAttrs;
          275|       pkgs = fromTOML (builtins.readFile manifest);
             |              ^
          276|     in

       … while evaluating the argument passed to builtins.fromTOML

       … while calling the 'readFile' builtin
         at /nix/store/b1gwcwpnssjyz76q7z090wya6b007v6k-nixpkgs-mozilla-src/rust-overlay.nix:275:24:
          274|       inherit (super.lib) flip mapAttrs;
          275|       pkgs = fromTOML (builtins.readFile manifest);
             |                        ^
          276|     in

       … while realising the context of path '/nix/store/piscm1b6wh0xixx52b33wm6xkaq4bmb7-channel-rust-nightly-2024-01-24.toml'
```
In this case, the correct URL would be: https://static.rust-lang.org/dist/2024-01-24/channel-rust-nightly.toml

## Proposed solution
Parse the `channel` key's value to obtain information about the channel (e.g. nightly) and the date.

## What's still missing?
My solution at this point only supports `channel` values of `stable`, `beta` and `nightly`. It needs to be extended to support versioned channels, but I currently lack the time to do so. Nevertheless, this should fix #287 and similar problems. That's why I though I should leave the fix here. Let me know if anything is missing, then I'll might look into it again in June.

Have a nice week!