### PR TITLE
Fix build for removal of firefox-{beta,devedition}-bin from nixpkgs

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -150,6 +150,7 @@ let
           version = version.version;
           sources = { inherit (info) url sha512; };
         };
+      } // super.lib.optionalAttrs (super.lib.functionArgs self.firefox-bin-unwrapped.override ? channel) {
         channel = version.channel;
       } // super.lib.optionalAttrs (self.firefox-bin-unwrapped.passthru ? applicationName) {
         applicationName = version.name;


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/pull/414510

This has an unfortunate side effect of renaming the `firefox-beta`, `firefox-devedition`, `firefox-nightly` binaries to `firefox` on affected nixpkgs versions.