### PR TITLE
make the flake example code visible

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,7 @@ overlays in this repository. To use it in your own flake, add it as
 an input to your ``flake.nix``:
 
 .. code:: nix
+
  {
    inputs.nixpkgs.url = github:NixOS/nixpkgs;
    inputs.nixpkgs-mozilla.url = github:mozilla/nixpkgs-mozilla;


### PR DESCRIPTION
The example code for flake usage wasn't visible for some reason. Adding a new line appears to fix this.